### PR TITLE
Fixed updating and querying of ingress rules

### DIFF
--- a/src/@providers/traefik/provider.ts
+++ b/src/@providers/traefik/provider.ts
@@ -15,17 +15,20 @@ export default class TraefikProvider extends Provider<TraefikCredentials> {
     namespace: new TraefikNamespaceService(this.name, this.credentials, this.providerStore),
   };
 
-  public testCredentials(): Promise<boolean> {
+  public async testCredentials(): Promise<boolean> {
     switch (this.credentials.type) {
       case 'volume': {
         const account = this.providerStore.getProvider(this.credentials.account);
         if (!account) {
-          return Promise.resolve(false);
+          return false;
         } else if (!account.resources.task || !('apply' in account.resources.task)) {
-          return Promise.resolve(false);
+          return false;
+        } else if (!account.resources.volume) {
+          return false;
         }
 
-        return Promise.resolve(true);
+        const volume = await account.resources.volume.get(this.credentials.volume);
+        return Boolean(volume);
       }
     }
   }

--- a/src/@providers/traefik/services/ingress-rule.ts
+++ b/src/@providers/traefik/services/ingress-rule.ts
@@ -35,13 +35,13 @@ export class TraefikIngressRuleService extends CrudResourceService<'ingressRule'
     const config = yaml.load(contents) as TraefikFormattedIngressRule;
 
     let host = '';
-    const hostMatches = config.http.routers[id].rule.match(/Host\(`(.*)`\)/);
+    const hostMatches = config.http.routers[id].rule.match(/Host\(`([^\s]+)`\)/);
     if (hostMatches && hostMatches.length > 1) {
       host = hostMatches[1];
     }
 
     let ingressPath = '/';
-    const pathMatches = config.http.routers[id].rule.match(/PathPrefix\(`(.*)`\)/);
+    const pathMatches = config.http.routers[id].rule.match(/PathPrefix\(`([^\s]+)`\)/);
     if (pathMatches && pathMatches.length > 1) {
       ingressPath = pathMatches[1];
     }
@@ -164,10 +164,10 @@ export class TraefikIngressRuleService extends CrudResourceService<'ingressRule'
 
     const host = hostParts.join('.');
     // deno-fmt-ignore
-    const rules = ['Host(`' + host + '`)'];
+    const rules = ['Host(\\\`' + host + '\\\`)'];
     if (inputs.path) {
       // deno-fmt-ignore
-      rules.push('PathPrefix(`' + inputs.path + '`)');
+      rules.push('PathPrefix(\\\`' + inputs.path + '\\\`)');
     }
 
     const newEntry: TraefikFormattedIngressRule = {


### PR DESCRIPTION
## Description

- Fixed updating of ingress rules. Backticks weren't being escaped so Host and PathPrefix were empty on update flows.
- Fixed querying of individual ingress rules. Regex was incorrect for parsing host and path.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Smoke testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
