### PR TITLE
Replace dots wrapper with raw API calls

### DIFF
--- a/src/@providers/digitalocean/provider.ts
+++ b/src/@providers/digitalocean/provider.ts
@@ -42,6 +42,7 @@ export default class DigitaloceanProvider extends Provider<DigitaloceanCredentia
   };
 
   public async testCredentials(): Promise<boolean> {
+    return true;
     try {
       const dots = createApiClient({ token: this.credentials.token });
       await dots.account.getAccount();

--- a/src/@providers/digitalocean/provider.ts
+++ b/src/@providers/digitalocean/provider.ts
@@ -1,4 +1,3 @@
-import { createApiClient } from 'dots-wrapper';
 import { Provider } from '../provider.ts';
 import { CldctlTestResource } from '../tests.ts';
 import { DigitaloceanCredentials, DigitaloceanCredentialsSchema } from './credentials.ts';
@@ -19,6 +18,7 @@ import { DigitalOceanDatabaseTest } from './tests/database.ts';
 import { DigitalOceanDnsRecordTest } from './tests/dns-record.ts';
 import { DigitalOceanDnsZoneTest } from './tests/dns-zone.ts';
 import { DigitalOceanVpcTest } from './tests/vpc.ts';
+import { digitalOceanApiRequest } from './utils.ts';
 
 export default class DigitaloceanProvider extends Provider<DigitaloceanCredentials> {
   readonly type = 'digitalocean';
@@ -42,10 +42,11 @@ export default class DigitaloceanProvider extends Provider<DigitaloceanCredentia
   };
 
   public async testCredentials(): Promise<boolean> {
-    return true;
     try {
-      const dots = createApiClient({ token: this.credentials.token });
-      await dots.account.getAccount();
+      await digitalOceanApiRequest({
+        credentials: this.credentials,
+        path: '/account',
+      });
     } catch {
       return false;
     }

--- a/src/@providers/digitalocean/services/database-type.ts
+++ b/src/@providers/digitalocean/services/database-type.ts
@@ -1,16 +1,13 @@
-import { createApiClient } from 'dots-wrapper';
 import { ResourceOutputs } from '../../../@resources/index.ts';
 import { PagingOptions, PagingResponse } from '../../../utils/paging.ts';
 import { ResourceService } from '../../base.service.ts';
 import { ProviderStore } from '../../store.ts';
 import { DigitaloceanCredentials } from '../credentials.ts';
+import { digitalOceanApiRequest } from '../utils.ts';
 
 export class DigitaloceanDatabaseTypeService extends ResourceService<'databaseType', DigitaloceanCredentials> {
-  private client: ReturnType<typeof createApiClient>;
-
   constructor(accountName: string, credentials: DigitaloceanCredentials, providerStore: ProviderStore) {
     super(accountName, credentials, providerStore);
-    this.client = createApiClient({ token: credentials.token });
   }
 
   get(_id: string): Promise<ResourceOutputs['databaseType'] | undefined> {
@@ -22,9 +19,10 @@ export class DigitaloceanDatabaseTypeService extends ResourceService<'databaseTy
     _filterOptions?: Partial<ResourceOutputs['databaseType']>,
     _pagingOptions?: Partial<PagingOptions>,
   ): Promise<PagingResponse<ResourceOutputs['databaseType']>> {
-    const {
-      data: { options },
-    } = await this.client.database.listDatabaseOptions();
+    const options = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: '/databases/options',
+    })).options;
     const types: ResourceOutputs['databaseType'][] = [];
     for (const database_name of Object.keys(options)) {
       types.push({

--- a/src/@providers/digitalocean/services/database.ts
+++ b/src/@providers/digitalocean/services/database.ts
@@ -1,6 +1,4 @@
 import { Construct } from 'constructs';
-import { createApiClient } from 'dots-wrapper';
-import { IDatabaseCluster } from 'dots-wrapper/dist/database/index.ts';
 import { ResourceOutputs } from '../../../@resources/index.ts';
 import { PagingOptions, PagingResponse } from '../../../utils/paging.ts';
 import { ResourcePresets } from '../../base.service.ts';
@@ -9,19 +7,17 @@ import { TerraformResourceService } from '../../terraform.service.ts';
 import { DigitaloceanProvider as TerraformDigitaloceanProvider } from '../.gen/providers/digitalocean/provider/index.ts';
 import { DigitaloceanCredentials } from '../credentials.ts';
 import { DigitaloceanDatabaseModule } from '../modules/database.ts';
+import { digitalOceanApiRequest } from '../utils.ts';
 
 export class DigitaloceanDatabaseService extends TerraformResourceService<'database', DigitaloceanCredentials> {
-  private client: ReturnType<typeof createApiClient>;
-
   readonly terraform_version = '1.4.5';
   readonly construct = DigitaloceanDatabaseModule;
 
   constructor(accountName: string, credentials: DigitaloceanCredentials, providerStore: ProviderStore) {
     super(accountName, credentials, providerStore);
-    this.client = createApiClient({ token: credentials.token });
   }
 
-  private normalizeDatabase(database: IDatabaseCluster): ResourceOutputs['database'] {
+  private normalizeDatabase(database: any): ResourceOutputs['database'] {
     return {
       id: database.id,
       host: database.connection.host,
@@ -39,12 +35,11 @@ export class DigitaloceanDatabaseService extends TerraformResourceService<'datab
   }
 
   async get(id: string): Promise<ResourceOutputs['database'] | undefined> {
-    const {
-      data: { database },
-    } = await this.client.database.getDatabaseCluster({
-      database_cluster_id: id,
+    const cluster = await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: `/databases/${id}`,
     });
-    return this.normalizeDatabase(database);
+    return this.normalizeDatabase(cluster.database);
   }
 
   // TODO: implement filter
@@ -52,12 +47,13 @@ export class DigitaloceanDatabaseService extends TerraformResourceService<'datab
     _filterOptions?: Partial<ResourceOutputs['database']>,
     _pagingOptions?: Partial<PagingOptions>,
   ): Promise<PagingResponse<ResourceOutputs['database']>> {
-    const {
-      data: { databases },
-    } = await this.client.database.listDatabaseClusters({});
+    const databases = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: `/databases`,
+    })).databases;
     return {
       total: databases.length,
-      rows: databases.map((element) => this.normalizeDatabase(element)),
+      rows: databases.map((element: any) => this.normalizeDatabase(element)),
     };
   }
 

--- a/src/@providers/digitalocean/services/dns-record.ts
+++ b/src/@providers/digitalocean/services/dns-record.ts
@@ -39,8 +39,7 @@ export class DigitaloceanDnsRecordService extends TerraformResourceService<'dnsR
         recordType: domain_record.type || '',
         managedZone: managed_zone,
       };
-    } catch (error) {
-      console.log(error);
+    } catch {
       return undefined;
     }
   }

--- a/src/@providers/digitalocean/services/dns-record.ts
+++ b/src/@providers/digitalocean/services/dns-record.ts
@@ -1,5 +1,4 @@
 import { Construct } from 'constructs';
-import { createApiClient } from 'dots-wrapper';
 import { ResourceOutputs } from '../../../@resources/index.ts';
 import { PagingOptions, PagingResponse } from '../../../utils/paging.ts';
 import { InputValidators } from '../../base.service.ts';
@@ -11,14 +10,11 @@ import { DigitaloceanDnsRecordModule } from '../modules/dns-record.ts';
 import { digitalOceanApiRequest } from '../utils.ts';
 
 export class DigitaloceanDnsRecordService extends TerraformResourceService<'dnsRecord', DigitaloceanCredentials> {
-  private client: ReturnType<typeof createApiClient>;
-
   readonly terraform_version = '1.4.5';
   readonly construct = DigitaloceanDnsRecordModule;
 
   constructor(accountName: string, credentials: DigitaloceanCredentials, providerStore: ProviderStore) {
     super(accountName, credentials, providerStore);
-    this.client = createApiClient({ token: credentials.token });
   }
 
   public configureTerraformProviders(scope: Construct): TerraformDigitaloceanProvider {

--- a/src/@providers/digitalocean/services/dns-record.ts
+++ b/src/@providers/digitalocean/services/dns-record.ts
@@ -8,6 +8,7 @@ import { TerraformResourceService } from '../../terraform.service.ts';
 import { DigitaloceanProvider as TerraformDigitaloceanProvider } from '../.gen/providers/digitalocean/provider/index.ts';
 import { DigitaloceanCredentials } from '../credentials.ts';
 import { DigitaloceanDnsRecordModule } from '../modules/dns-record.ts';
+import { digitalOceanApiRequest } from '../utils.ts';
 
 export class DigitaloceanDnsRecordService extends TerraformResourceService<'dnsRecord', DigitaloceanCredentials> {
   private client: ReturnType<typeof createApiClient>;
@@ -27,15 +28,13 @@ export class DigitaloceanDnsRecordService extends TerraformResourceService<'dnsR
   }
 
   async get(id: string): Promise<ResourceOutputs['dnsRecord'] | undefined> {
-    const [managed_zone, record_id] = id.split('/');
+    const [managed_zone, record_id] = id.split(',');
 
     try {
-      const {
-        data: { domain_record },
-      } = await this.client.domain.getDomainRecord({
-        domain_name: managed_zone,
-        domain_record_id: Number.parseInt(record_id),
-      });
+      const domain_record = (await digitalOceanApiRequest({
+        credentials: this.credentials,
+        path: `/domains/${managed_zone}/records/${record_id}`,
+      })).domain_record;
 
       return {
         id: domain_record.id.toString() || '',
@@ -44,7 +43,8 @@ export class DigitaloceanDnsRecordService extends TerraformResourceService<'dnsR
         recordType: domain_record.type || '',
         managedZone: managed_zone,
       };
-    } catch {
+    } catch (error) {
+      console.log(error);
       return undefined;
     }
   }
@@ -53,18 +53,18 @@ export class DigitaloceanDnsRecordService extends TerraformResourceService<'dnsR
     _filterOptions?: Partial<ResourceOutputs['dnsRecord']>,
     _pagingOptions?: Partial<PagingOptions>,
   ): Promise<PagingResponse<ResourceOutputs['dnsRecord']>> {
-    const {
-      data: { domains },
-    } = await this.client.domain.listDomains({});
+    const domains = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: `/domains`,
+    })).domains;
 
     const dns_record_rows: ResourceOutputs['dnsRecord'][] = [];
     for (const dns_zone of domains || []) {
       if (dns_zone.name) {
-        const {
-          data: { domain_records },
-        } = await this.client.domain.listDomainRecords({
-          domain_name: dns_zone.name,
-        });
+        const domain_records = (await digitalOceanApiRequest({
+          credentials: this.credentials,
+          path: `/domains/${dns_zone.name}/records`,
+        })).domain_records;
 
         for (const record of domain_records || []) {
           dns_record_rows.push({

--- a/src/@providers/digitalocean/services/region.ts
+++ b/src/@providers/digitalocean/services/region.ts
@@ -1,23 +1,21 @@
-import { createApiClient } from 'dots-wrapper';
 import { ResourceOutputs } from '../../../@resources/index.ts';
 import { PagingOptions, PagingResponse } from '../../../utils/paging.ts';
 import { ResourceService } from '../../base.service.ts';
 import { ProviderStore } from '../../store.ts';
 import { DigitaloceanCredentials } from '../credentials.ts';
+import { digitalOceanApiRequest } from '../utils.ts';
 
 export class DigitaloceanRegionService extends ResourceService<'region', DigitaloceanCredentials> {
-  private client: ReturnType<typeof createApiClient>;
-
   constructor(accountName: string, credentials: DigitaloceanCredentials, providerStore: ProviderStore) {
     super(accountName, credentials, providerStore);
-    this.client = createApiClient({ token: credentials.token });
   }
 
   async get(id: string): Promise<ResourceOutputs['region'] | undefined> {
-    const {
-      data: { regions },
-    } = await this.client.region.listRegions({});
-    const region = regions.find((r) => r.slug === id);
+    const regions = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: '/regions',
+    })).regions;
+    const region = regions.find((r: any) => r.slug === id);
     return region
       ? {
         id: region.slug,
@@ -31,11 +29,14 @@ export class DigitaloceanRegionService extends ResourceService<'region', Digital
     _filterOptions?: Partial<ResourceOutputs['region']>,
     _pagingOptions?: Partial<PagingOptions>,
   ): Promise<PagingResponse<ResourceOutputs['region']>> {
-    const options = await this.client.kubernetes.listAvailableOptionsOfKubernetes();
-    const regions = options.data.options.regions;
+    const options = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: '/kubernetes/options',
+    })).options;
+    const regions = options.regions;
     return {
       total: regions.length,
-      rows: regions.map((region) => ({
+      rows: regions.map((region: any) => ({
         id: region.slug,
         name: region.name,
         type: 'region',

--- a/src/@providers/digitalocean/services/vpc.ts
+++ b/src/@providers/digitalocean/services/vpc.ts
@@ -1,6 +1,4 @@
 import { Construct } from 'constructs';
-import { createApiClient } from 'dots-wrapper';
-import { IVpc } from 'dots-wrapper/dist/vpc/index.ts';
 import { ResourceOutputs } from '../../../@resources/index.ts';
 import { PagingOptions, PagingResponse } from '../../../utils/paging.ts';
 import { InputValidators } from '../../base.service.ts';
@@ -9,19 +7,17 @@ import { TerraformResourceService } from '../../terraform.service.ts';
 import { DigitaloceanProvider as TerraformDigitaloceanProvider } from '../.gen/providers/digitalocean/provider/index.ts';
 import { DigitaloceanCredentials } from '../credentials.ts';
 import { DigitaloceanVpcModule } from '../modules/vpc.ts';
+import { digitalOceanApiRequest } from '../utils.ts';
 
 export class DigitaloceanVpcService extends TerraformResourceService<'vpc', DigitaloceanCredentials> {
-  private client: ReturnType<typeof createApiClient>;
-
   readonly terraform_version = '1.4.5';
   readonly construct = DigitaloceanVpcModule;
 
   constructor(accountName: string, credentials: DigitaloceanCredentials, providerStore: ProviderStore) {
     super(accountName, credentials, providerStore);
-    this.client = createApiClient({ token: credentials.token });
   }
 
-  private normalizeVpc(vpc: IVpc): ResourceOutputs['vpc'] {
+  private normalizeVpc(vpc: any): ResourceOutputs['vpc'] {
     return {
       id: vpc.id,
       name: vpc.name,
@@ -37,9 +33,10 @@ export class DigitaloceanVpcService extends TerraformResourceService<'vpc', Digi
   }
 
   async get(id: string): Promise<ResourceOutputs['vpc']> {
-    const {
-      data: { vpc },
-    } = await this.client.vpc.getVpc({ vpc_id: id });
+    const vpc = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: `/vpcs/${id}`,
+    })).vpc;
     return this.normalizeVpc(vpc);
   }
 
@@ -47,17 +44,18 @@ export class DigitaloceanVpcService extends TerraformResourceService<'vpc', Digi
     filterOptions?: Partial<ResourceOutputs['vpc']>,
     _pagingOptions?: Partial<PagingOptions>,
   ): Promise<PagingResponse<ResourceOutputs['vpc']>> {
-    const {
-      data: { vpcs },
-    } = await this.client.vpc.listVpcs({});
+    const vpcs = (await digitalOceanApiRequest({
+      credentials: this.credentials,
+      path: `/vpcs`,
+    })).vpcs;
     const regionVpcs = filterOptions?.region
-      ? vpcs.filter((vpc) => {
+      ? vpcs.filter((vpc: any) => {
         return vpc.region === filterOptions.region;
       })
       : vpcs;
     return {
       total: regionVpcs.length,
-      rows: regionVpcs.map((vpc) => this.normalizeVpc(vpc)),
+      rows: regionVpcs.map((vpc: any) => this.normalizeVpc(vpc)),
     };
   }
 

--- a/src/@providers/digitalocean/utils.ts
+++ b/src/@providers/digitalocean/utils.ts
@@ -1,0 +1,25 @@
+import { DigitaloceanCredentials } from './credentials.ts';
+
+export enum DigitalOceanApiMethods {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+}
+
+export async function digitalOceanApiRequest(options: {
+  credentials: DigitaloceanCredentials;
+  path: string;
+  method?: DigitalOceanApiMethods;
+}): Promise<any> {
+  const headers = {
+    'Authorization': `Bearer ${options.credentials.token}`,
+    'Content-Type': 'application/json',
+  };
+  const method = options.method || DigitalOceanApiMethods.GET;
+  const response = await fetch(`https://api.digitalocean.com/v2${options.path}`, {
+    method,
+    headers,
+  });
+  return JSON.parse(await response.text());
+}

--- a/src/@providers/digitalocean/utils.ts
+++ b/src/@providers/digitalocean/utils.ts
@@ -11,15 +11,27 @@ export async function digitalOceanApiRequest(options: {
   credentials: DigitaloceanCredentials;
   path: string;
   method?: DigitalOceanApiMethods;
+  paging?: {
+    per_page?: number;
+    page?: number;
+  };
 }): Promise<any> {
   const headers = {
     'Authorization': `Bearer ${options.credentials.token}`,
     'Content-Type': 'application/json',
   };
+  const query = new URLSearchParams();
+  if (options.paging?.per_page) {
+    query.append('per_page', options.paging.per_page.toString());
+  }
+  const url = `https://api.digitalocean.com/v2${options.path}${query.size > 0 ? '?' + query : ''}`;
   const method = options.method || DigitalOceanApiMethods.GET;
-  const response = await fetch(`https://api.digitalocean.com/v2${options.path}`, {
+  const response = await fetch(url, {
     method,
     headers,
   });
+  if ((await response).status != 200) {
+    throw new Error(`DigitalOcean API request failed: ${JSON.stringify(await response.json())}`);
+  }
   return JSON.parse(await response.text());
 }


### PR DESCRIPTION
## Description

We were seeing an issue where Deno has been unable to use axios. This PR removes the dots-wrapper for now and instead uses the Fetch api. Now we no longer have issues querying DO resources on the current version of Deno. Eventually we should undo these changes once Deno fixes the issue, but for now this unblocks our ability to automate the build process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Literally ran the command for every resource to verify they all worked as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
