### PR TITLE
Added edge between deployments and services

### DIFF
--- a/src/@providers/kubernetes/modules/service.ts
+++ b/src/@providers/kubernetes/modules/service.ts
@@ -68,6 +68,7 @@ export class KubernetesServiceModule extends ResourceModule<'service', Kubernete
       url,
       username: this.inputs?.username || '',
       password: this.inputs?.password || '',
+      account: this.inputs?.account || '',
     };
   }
 

--- a/src/@providers/kubernetes/services/service.ts
+++ b/src/@providers/kubernetes/services/service.ts
@@ -47,6 +47,7 @@ export class KubernetesServiceService extends TerraformResourceService<'service'
         port: ports[0].port,
         protocol: 'http',
         url: `http://${body.metadata.name}:${ports[0].port}`,
+        account: this.accountName,
       };
     } catch {
       return undefined;
@@ -74,6 +75,7 @@ export class KubernetesServiceService extends TerraformResourceService<'service'
             port: ports[0].port,
             protocol: 'http',
             url: `http://${service.metadata.name}:${ports[0].port}`,
+            account: this.accountName,
           });
         }
       }

--- a/src/@providers/traefik/services/service.ts
+++ b/src/@providers/traefik/services/service.ts
@@ -55,6 +55,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
         port: 80,
         protocol: 'http',
         url: `http://${host}`,
+        account: this.accountName,
       };
     } else if (entry.tcp) {
       let host = '';
@@ -71,6 +72,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
         port: 80,
         protocol: 'tcp',
         url: `tcp://${host}`,
+        account: this.accountName,
       };
     }
   }
@@ -105,6 +107,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
           port: 80,
           protocol: 'http',
           url: `http://${host}`,
+          account: this.accountName,
         };
       } else if (config.tcp) {
         let host = '';
@@ -121,6 +124,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
           port: 80,
           protocol: 'tcp',
           url: `tcp://${host}`,
+          account: this.accountName,
         };
       }
 
@@ -194,6 +198,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
       username: inputs.username || '',
       password: inputs.password || '',
       url,
+      account: this.accountName,
     };
   }
 
@@ -284,6 +289,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
       username: inputs.username || '',
       password: inputs.password || '',
       url,
+      account: this.accountName,
     };
   }
 

--- a/src/@resources/deployment/inputs.schema.json
+++ b/src/@resources/deployment/inputs.schema.json
@@ -141,6 +141,28 @@
           "description": "Number of replicas of the deployment to run",
           "type": "number"
         },
+        "services": {
+          "description": "Services this deployment should register itself with",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "account": {
+                "description": "The account the deployment can use to register itself with the service.",
+                "type": "string"
+              },
+              "id": {
+                "description": "Unique ID of the service the deployment should attach itself to",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "account"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
         "sidecars": {
           "description": "A set of additional containers to run as part of each replica",
           "items": {

--- a/src/@resources/deployment/inputs.ts
+++ b/src/@resources/deployment/inputs.ts
@@ -180,6 +180,21 @@ export type DeploymentInputs = {
    * A set of additional containers to run as part of each replica
    */
   sidecars?: Array<Container>;
+
+  /**
+   * Services this deployment should register itself with
+   */
+  services?: Array<{
+    /**
+     * Unique ID of the service the deployment should attach itself to
+     */
+    id: string;
+
+    /**
+     * The account the deployment can use to register itself with the service.
+     */
+    account: string;
+  }>;
 } & Container;
 
 export default DeploymentInputs;

--- a/src/@resources/input.schema.json
+++ b/src/@resources/input.schema.json
@@ -609,6 +609,28 @@
                 "description": "Number of replicas of the deployment to run",
                 "type": "number"
               },
+              "services": {
+                "description": "Services this deployment should register itself with",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "account": {
+                      "description": "The account the deployment can use to register itself with the service.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "Unique ID of the service the deployment should attach itself to",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "account"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
               "sidecars": {
                 "description": "A set of additional containers to run as part of each replica",
                 "items": {

--- a/src/@resources/service/outputs.ts
+++ b/src/@resources/service/outputs.ts
@@ -28,6 +28,11 @@ export type ServiceOutputs = {
    * Fully resolvable URL of the service
    */
   url: string;
+
+  /**
+   * The account used to connect to this service
+   */
+  account: string;
 };
 
 export default ServiceOutputs;

--- a/src/@resources/types.ts
+++ b/src/@resources/types.ts
@@ -74,8 +74,7 @@ export type ResourceType =
   | 'service'
   | 'task'
   | 'volume'
-  | 'vpc'
-;
+  | 'vpc';
 
 export const ResourceTypeList: ResourceType[] = [
   'arcctlAccount',

--- a/src/@resources/types.ts
+++ b/src/@resources/types.ts
@@ -74,7 +74,8 @@ export type ResourceType =
   | 'service'
   | 'task'
   | 'volume'
-  | 'vpc';
+  | 'vpc'
+;
 
 export const ResourceTypeList: ResourceType[] = [
   'arcctlAccount',

--- a/src/components/__tests__/version-helper.ts
+++ b/src/components/__tests__/version-helper.ts
@@ -277,17 +277,40 @@ export const testServiceGeneration = (
     },
   });
 
-  assertArrayIncludes(graph.nodes, [service_node]);
-  assertArrayIncludes(graph.edges, [
-    new CloudEdge({
-      from: service_node.id,
-      to: CloudNode.genId({
-        type: 'deployment',
+  const deployment_node = new CloudNode({
+    name: options.deployment_name,
+    component: 'component',
+    environment: 'environment',
+    inputs: {
+      type: 'deployment',
+      name: CloudNode.genResourceId({
         name: options.deployment_name,
         component: 'component',
         environment: 'environment',
       }),
+      image: 'nginx:1.14.2',
+      replicas: 1,
+      services: [
+        {
+          id: `\${{ ${service_node.id}.id }}`,
+          account: `\${{ ${service_node.id}.account }}`,
+        },
+      ],
+      volume_mounts: [],
+    },
+  });
+
+  assertArrayIncludes(graph.nodes, [deployment_node, service_node]);
+  assertArrayIncludes(graph.edges, [
+    new CloudEdge({
+      from: service_node.id,
+      to: deployment_node.id,
       required: false,
+    }),
+    new CloudEdge({
+      from: deployment_node.id,
+      to: service_node.id,
+      required: true,
     }),
   ]);
 };


### PR DESCRIPTION
## Description

We ran into some potential hiccups with the way we register deployments/pods with the services that connect to them. With some providers (e.g. google cloud run), the URLs for the "deployments" aren't deterministic, which means we'll need to wait for its URL to be generated before it can register itself with the service discovery solution. 

In order to accomplish this, I've added a relationship in our graph generation between a deployment and the services that connect to it so that the deployment will be capable of "registering" itself upon completion.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Updated unit tests for services to ensure the deployment is updated correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
