### PR TITLE
Renamed a lot of stuff in our README docs

### DIFF
--- a/src/@providers/README.md
+++ b/src/@providers/README.md
@@ -1,9 +1,9 @@
-# cldctl providers
+# Architect Providers
 
-Providers are arcctl plugins that can list, get, create, update, and/or delete the [resources](../%40resources/) supported by arcctl. Developers can register their cloud provider "accounts" with
-arcctl in order to let the provider help them create cloud [resources](../%40resources/) more easily.
+Providers are Architect's plugins that can list, get, create, update, and/or delete the [resources](../%40resources/) supported by Architect. Developers can register their cloud provider "accounts" with
+Architect in order to let the provider help them create cloud [resources](../%40resources/) more easily.
 
-For anyone familiar with Terraform the concept is almost the same, but arcctl providers MUST conform to the input/output expectations of arcctl resources and cannot define their own resources. This helps the framework better serve the needs of developers by letting them focus on their applications instead of their infrastructure.
+For anyone familiar with Terraform the concept is almost the same, but Architect providers MUST conform to the input/output expectations of Architect resources and cannot define their own resources. This helps the framework better serve the needs of developers by letting them focus on their applications instead of their infrastructure.
 
 ## Using providers
 

--- a/src/@providers/README.md
+++ b/src/@providers/README.md
@@ -1,7 +1,6 @@
 # Architect Providers
 
-Providers are Architect's plugins that can list, get, create, update, and/or delete the [resources](../%40resources/) supported by Architect. Developers can register their cloud provider "accounts" with
-Architect in order to let the provider help them create cloud [resources](../%40resources/) more easily.
+Providers are plugins that can list, get, create, update, and/or delete the [resources](../%40resources/) supported by Architect. Developers can register their cloud provider "accounts" with Architect in order to let the provider help them create cloud [resources](../%40resources/) more easily.
 
 For anyone familiar with Terraform the concept is almost the same, but Architect providers MUST conform to the input/output expectations of Architect resources and cannot define their own resources. This helps the framework better serve the needs of developers by letting them focus on their applications instead of their infrastructure.
 

--- a/src/@resources/README.md
+++ b/src/@resources/README.md
@@ -1,12 +1,12 @@
-# ArcCtl Resources
+# Architect Resources
 
-In order to ensure that applications are portable, ArcCtl has curated a set of
+In order to ensure that applications are portable, Architect has curated a set of
 cloud resource "contracts" that help [component](../components/) developers collaborate with
 [datacenter](../datacenters/) operators. Components are must be able to be converted
 into a graph of these resources, and in doing so datacenters can predict what types of
 resources need to be created and write rules for how they should be enriched.
 
-In this folder, you'll find a list of all the resources supported by ArcCtl. To learn more
+In this folder, you'll find a list of all the resources supported by Architect. To learn more
 about any particular resource, simply open up the resource folder and check out its
 own README.
 

--- a/src/datacenters/README.md
+++ b/src/datacenters/README.md
@@ -1,6 +1,6 @@
-# ArcCtl Datacenters
+# Architect Datacenters
 
-ArcCtl datacenters are packages of configuration and rules dictating how
+Architect Datacenters are packages of configuration and rules dictating how
 cloud resources should behave. Datacenters can create datacenter-wide
 resources, environment-scoped resources, and can even mutate application
 resources derived from components deployed to the datacenter.
@@ -12,7 +12,7 @@ was done for two reasons:
 2. To give operators a way to control application behavior without compromising developer self-service
 
 With datacenters, operators can configure the API gateway, service mesh, databases, DNS providers and
-other global utilities and rules for all environments hosted by the datacenter. ArcCtl will automatically
+other global utilities and rules for all environments hosted by the datacenter. Architect will automatically
 match the cloud resources developers deploy with the rules of the datacenter to ensure everything gets
 enriched the way ops teams need. Basically, datacenters let you make your own PaaS.
 
@@ -47,7 +47,7 @@ Datacenter created successfully
 ## Updating datacenters
 
 Datacenters can be updated as easily as they can be created. Simply provide a new
-datacenter configuration file, and arcctl will propogate the changes:
+datacenter configuration file, and Architect will propogate the changes:
 
 ```sh
 $ arcctl apply datacenter digitalocean ./v1/examples/digitalocean.yml
@@ -69,7 +69,7 @@ If the datacenter is actively hosting environments, all environments will also b
 
 ## The datacenter configuration file
 
-ArcCtl uses versioning to allow its core schemas to grow and evolve. To learn how to author a datacenter
+Architect uses versioning to allow its core schemas to grow and evolve. To learn how to author a datacenter
 configuration file, select a schema version below:
 
 - [v1 (latest)](./v1/)

--- a/src/datacenters/v1/README.md
+++ b/src/datacenters/v1/README.md
@@ -1,4 +1,4 @@
-# v1 datacenter schema
+# Architect Datacenter Schema - v1
 
 The v1 datacenter schema is designed to allow operators to control resources in three
 different scopes:
@@ -28,7 +28,7 @@ resources:
     region: ${{ variables.region }}
 ```
 
-Every resource must declare a `type` that matches one of the arcctl [resource types](../../%40resources/)
+Every resource must declare a `type` that matches one of the Architect [resource types](../../%40resources/)
 as well as an [`account`](../../%40providers/) capable of creating said type of resource. Once declared, the outputs of said
 resource type can be referenced elsewhere in the datacenter schema using the expression syntax,
 `${{ resources.<resource-key>.<output-key> }}`.
@@ -53,7 +53,7 @@ resources:
 
 ## Datacenter accounts
 
-In addition to creating arcctl resources, datacenters can also register new cloud accounts
+In addition to creating [Architect Resources](../../@resources), datacenters can also register new cloud accounts
 with one of the supported providers automatically. This can help setup complex sequences
 that allow you to create resources within newly created cloud accounts without additional
 steps.
@@ -88,7 +88,7 @@ environment:
 
 ### Environment resources
 
-Like with the root scope, arcctl resources can be declared within the environment
+Like with the root scope, [Architect Resources](../../@resources) can be declared within the environment
 specification as well. When declared here, one of each resource will be created for
 each environment within the datacenter.
 
@@ -113,7 +113,7 @@ environment:
 
 ### Environment accounts
 
-Also as with the root scope, new arcctl accounts can be registered for each enviroment
+Also as with the root scope, new [Architect Accounts](../../@providers) can be registered for each enviroment
 that broker access to environment-scoped resources:
 
 ```yml
@@ -206,7 +206,7 @@ inputs are called variables:
 ```yml
 variables:
   account:
-    # Variables can be arcctl resources
+    # Variables can be Architect Resources
     type: arcctlAccount
     description: The DigitalOcean account used to power the environment
     provider: digitalocean
@@ -219,4 +219,4 @@ variables:
 Declared variables can be referenced anywhere else in the datacenter template that you'd like
 using the expression syntax, `${{ variables.<variable-name> }}`.
 
-In addition to [arcctl resources](../../%40resources/), variables can also be `string`, `number`, and `boolean` types.
+In addition to [Architect Resources](../../%40resources/), variables can also be `string`, `number`, and `boolean` types.

--- a/src/environments/README.md
+++ b/src/environments/README.md
@@ -1,11 +1,11 @@
-# ArcCtl Environments
+# Architect Environments
 
-Environments represent running instances of [components](../components/) that
+Environments represent running instances of [Components](../components/) that
 are made available to each other for integration. You likely have environments for
 things like `production` or `staging`, but may also create private environments for
 integration testing or everyday development.
 
-ArcCtl attempts to automate as much configuration for components as possible, but
+Architect attempts to automate as much configuration for components as possible, but
 there are still cases where owners will want to assign environment-specific rules
 and values.
 
@@ -34,7 +34,7 @@ at the path `./api1` (which must contain an architect.yml file at minimum), and 
 been tagged as `architect/auth:latest`. The environment will also be backed by the `my-datacenter`
 datacenter and will follow the rules of that datacenter for provisioning.
 
-In addition to the component(s) cited, arcctl will also deploy any dependencies of the cited components –
+In addition to the component(s) cited, Architect will also deploy any dependencies of the cited components –
 even if you don't specify them explicitly. By default, all components deployed implicitly as dependencies
 will attempt to deploy the `latest` tag of the component. You can specify other tags by including the
 component explicitly in the command:
@@ -136,7 +136,7 @@ $ arcctl destroy environment production
 
 ## The environment configuration file
 
-ArcCtl uses versioning to allow its core schemas to grow and evolve. To learn how to author an
+Architect uses versioning to allow its core schemas to grow and evolve. To learn how to author an
 environment configuration file, select a schema version below:
 
 - [v1 (latest)](./v1/)

--- a/src/environments/v1/README.md
+++ b/src/environments/v1/README.md
@@ -1,30 +1,68 @@
-# v1 environment schema
+# Architect Environment Schema - v1
 
-```yaml
-# locals allow you to re-use the same value in multiple
-# places in your schema file
-locals:
-  stripe_api_key: xyzpdq
+Architect Environment Schemas are packages of runtime configuration for one or more components
+that should co-exist in the same environment. Environments are backed by a single datacenter,
+and provide a format by which developers can merge their components with one another in a
+shared environment.
 
-# Declare which components should exist and how they should
-# be configured
+## Adding components
+
+The most basic feature of the environment schema is to provide a home for components and their
+configuration. To add a component to an environment, simply declare the component name and `source`
+in the schema file:
+
+```yml
 components:
-  # Components resolve dependencies by matching against
-  # this root key
   architect/smtp:
-    # This is how you specify the registry/tag where the
-    # component can be found
     source: registry.hub.docker.com/mailslurper/mailslurper:latest
+```
+
+The key in the `components` dictionary above represents the component name/repo. Other components
+in the environment that use a similar name for a dependency will resolve to the declared component.
+However unlikely a use-case it may be, this means you can fulfill dependency claims with entirely different
+components if you'd like:
+
+```yml
+components:
+  architect/smtp:
+    source: sendgrid/smtp:latest
+```
+
+### Scaling rules
+
+Another common set of values environments will provide to components are the number of replicas
+of each deployment to run. Obviously the default is one, but you can specify whatever value is
+appropriate for the environment:
+
+```yml
+components:
+  architect/smtp:
+    # ...
     deployments:
       mailslurper:
         replicas: 3
+      mailslurper-api:
+        autoscaling:
+          min_replicas: 2
+          max_replicas: 4
+```
 
+### Ingress configuration
+
+It is common for components to declare [`ingressRules`](../../@resources/ingressRule/) that 
+indicate that they wish to be exposed to the outside world. However, components are NOT able
+to safely decide on the specifics of each rule because they don't know if those values
+will collide with other components in the environment (e.g. two ingresses trying to listen
+on `api.my-domain.com`). 
+
+For this reason, common ingress configuration settings (like `path` and `subdomain`) can be
+specified in the environment.
+
+```yml
+components:
   # Full registry addresses are valid component names
-  registry.hub.docker.com/architect/auth:
-    source: registry.hub.docker.com/architect/auth:v2
-    # Ingress rules can be configured with unique tuples
-    # of subdomain/path, but cannot collide with other
-    # combinations in the environment
+  architect/auth:
+    # ...
     ingresses:
       api:
         subdomain: auth
@@ -34,10 +72,22 @@ components:
         path: /
       admin:
         subdomain: auth-admin
-        # Ingresses can also be flagged as internal so the
-        # datacenter can mount it to private gateways
         internal: true
-  
+```
+
+### Re-using values
+
+Do you have a configuration setting that gets re-used in several places inside the
+environment schema? You can use the `locals` keyword to declare the value in a single
+location to be referened elsewhere in the configuration:
+
+```yaml
+# locals allow you to re-use the same value in multiple
+# places in your schema file
+locals:
+  stripe_api_key: xyzpdq
+
+components:
   architect/app1:
     source: architect/app:latest
     secrets:
@@ -47,9 +97,16 @@ components:
     source: architect/app:latest
     secrets:
       stripe_key: ${{ locals.stripe_api_key }}
+```
 
-  architect/app-debug:
-    # Components can also be sourced from the local 
-    # filesystem
+### Running from source
+
+Want to test out a component before publishing it to a remote registry? You can specify
+the components live on your local filesystem by using the `file:` prefix on the `source`
+value for a component:
+
+```yml
+components:
+  architect/auth:
     source: file:./component/architect.yml
 ```

--- a/src/environments/v1/README.md
+++ b/src/environments/v1/README.md
@@ -49,11 +49,11 @@ components:
 
 ### Ingress configuration
 
-It is common for components to declare [`ingressRules`](../../@resources/ingressRule/) that 
+It is common for components to declare [`ingressRules`](../../@resources/ingressRule/) that
 indicate that they wish to be exposed to the outside world. However, components are NOT able
 to safely decide on the specifics of each rule because they don't know if those values
 will collide with other components in the environment (e.g. two ingresses trying to listen
-on `api.my-domain.com`). 
+on `api.my-domain.com`).
 
 For this reason, common ingress configuration settings (like `path` and `subdomain`) can be
 specified in the environment.


### PR DESCRIPTION
## Description

- Renamed usage of ArcCtl to Architect where appropriate
- Added content to environment schema docs

## Type of change

- [x] This change requires a documentation update
