### PR TITLE
build/push command improvements

### DIFF
--- a/src/@providers/gcp/modules/database.ts
+++ b/src/@providers/gcp/modules/database.ts
@@ -21,6 +21,7 @@ export class GoogleCloudDatabaseModule extends ResourceModule<'database', Google
       ? [
         new ProjectService(this, 'database-service', {
           service: 'compute.googleapis.com',
+          disableOnDestroy: false,
         }),
       ]
       : [];

--- a/src/@providers/gcp/modules/dns-record.ts
+++ b/src/@providers/gcp/modules/dns-record.ts
@@ -17,6 +17,7 @@ export class GoogleCloudDnsRecordModule extends ResourceModule<'dnsRecord', Goog
     const depends_on = [
       new ProjectService(this, 'dns-record-service', {
         service: 'dns.googleapis.com',
+        disableOnDestroy: false,
       }),
     ];
 

--- a/src/@providers/gcp/modules/dns-zone.ts
+++ b/src/@providers/gcp/modules/dns-zone.ts
@@ -25,6 +25,7 @@ export class GoogleCloudDnsZoneModule extends ResourceModule<'dnsZone', GoogleCl
         dependsOn: [
           new ProjectService(this, 'dns-zone-service', {
             service: 'dns.googleapis.com',
+            disableOnDestroy: false,
           }),
         ],
         name: this.inputs.name.replaceAll('.', '-').slice(0, -1),

--- a/src/@providers/gcp/modules/kubernetes-cluster.ts
+++ b/src/@providers/gcp/modules/kubernetes-cluster.ts
@@ -23,9 +23,11 @@ export class GoogleCloudKubernetesClusterModule extends ResourceModule<
       ? [
         new ProjectService(this, 'cluster-compute-service', {
           service: 'compute.googleapis.com',
+          disableOnDestroy: false,
         }),
         new ProjectService(this, 'cluster-container-service', {
           service: 'container.googleapis.com',
+          disableOnDestroy: false,
         }),
       ]
       : [];

--- a/src/@providers/gcp/modules/vpc.ts
+++ b/src/@providers/gcp/modules/vpc.ts
@@ -16,6 +16,7 @@ export class GoogleCloudVpcModule extends ResourceModule<'vpc', GoogleCloudCrede
       ? [
         new ProjectService(this, 'vpc-compute-service', {
           service: 'compute.googleapis.com',
+          disableOnDestroy: false,
         }),
       ]
       : [];

--- a/src/@providers/kubernetes/modules/namespace.ts
+++ b/src/@providers/kubernetes/modules/namespace.ts
@@ -11,7 +11,7 @@ export class KubernetesNamespaceModule extends ResourceModule<'namespace', Kuber
   constructor(scope: Construct, options: ResourceModuleOptions<'namespace', KubernetesCredentials>) {
     super(scope, options);
 
-    this.namespace = new Namespace(scope, 'namespace', {
+    this.namespace = new Namespace(this, 'namespace', {
       metadata: {
         name: this.inputs?.name || 'unknown',
       },

--- a/src/@providers/terraform.service.ts
+++ b/src/@providers/terraform.service.ts
@@ -419,10 +419,14 @@ export abstract class TerraformResourceService<
         },
       });
 
-      await this.tfPlan(cwd, {
+      const { stderr: plan_stderr } = await this.tfPlan(cwd, {
         logger: options.logger,
         destroy: true,
       });
+      if (plan_stderr && plan_stderr.length > 0) {
+        subscriber.error(new TextDecoder().decode(plan_stderr));
+        return;
+      }
 
       subscriber.next({
         status: {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -96,7 +96,7 @@ async function build_action(options: BuildOptions, context_file: string): Promis
     for (const tag of options.tag) {
       component = await component.tag(async (sourceRef: string, targetName: string) => {
         const imageRepository = new ImageRepository(tag);
-        const suffix = imageRepository.tag ? ':' + imageRepository.tag : '';q
+        const suffix = imageRepository.tag ? ':' + imageRepository.tag : '';
         const targetRef = path.join(imageRepository.registry, `${imageRepository.repository}-${targetName}${suffix}`);
 
         await exec('docker', { args: ['tag', sourceRef, targetRef] });

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -97,7 +97,13 @@ async function build_action(options: BuildOptions, context_file: string): Promis
       component = await component.tag(async (sourceRef: string, targetName: string) => {
         const imageRepository = new ImageRepository(tag);
         const suffix = imageRepository.tag ? ':' + imageRepository.tag : '';
-        const targetRef = path.join(imageRepository.registry, `${imageRepository.repository}--${targetName}${suffix}`);
+
+        // When the targetName matches the end of the "repository", e.g.
+        // using `-t myaccount/myimg:tag` with a build containing `myimg`, we don't want
+        // `myaccount/myimg-myimg:tag` as the ref.
+        const targetRef = imageRepository.repository.endsWith(targetName)
+          ? path.join(imageRepository.registry, `${imageRepository.repository}${suffix}`)
+          : path.join(imageRepository.registry, `${imageRepository.repository}-${targetName}${suffix}`);
 
         await exec('docker', { args: ['tag', sourceRef, targetRef] });
         return targetRef;

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -96,16 +96,11 @@ async function build_action(options: BuildOptions, context_file: string): Promis
     for (const tag of options.tag) {
       component = await component.tag(async (sourceRef: string, targetName: string) => {
         const imageRepository = new ImageRepository(tag);
-        const suffix = imageRepository.tag ? ':' + imageRepository.tag : '';
-
-        // When the targetName matches the end of the "repository", e.g.
-        // using `-t myaccount/myimg:tag` with a build containing `myimg`, we don't want
-        // `myaccount/myimg-myimg:tag` as the ref.
-        const targetRef = imageRepository.repository.endsWith(targetName)
-          ? path.join(imageRepository.registry, `${imageRepository.repository}${suffix}`)
-          : path.join(imageRepository.registry, `${imageRepository.repository}-${targetName}${suffix}`);
+        const suffix = imageRepository.tag ? ':' + imageRepository.tag : '';q
+        const targetRef = path.join(imageRepository.registry, `${imageRepository.repository}-${targetName}${suffix}`);
 
         await exec('docker', { args: ['tag', sourceRef, targetRef] });
+        console.log(`Image Tagged: ${targetRef}`);
         return targetRef;
       }, async (digest: string, deploymentName: string, volumeName: string) => {
         console.log(`Tagging volume ${volumeName} for deployment ${deploymentName} with digest ${digest}`);
@@ -116,8 +111,8 @@ async function build_action(options: BuildOptions, context_file: string): Promis
 
       const component_digest = await command_helper.componentStore.add(component);
       command_helper.componentStore.tag(component_digest, tag);
-      console.log(`Digest: ${component_digest}`);
-      console.log(`Tagged: ${tag}`);
+      console.log(`Component Digest: ${component_digest}`);
+      console.log(`Component Tagged: ${tag}`);
     }
   } else {
     console.log(`Digest: ${digest}`);

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -24,13 +24,15 @@ async function push_action(options: BuildOptions, tag: string): Promise<void> {
         Deno.exit(code);
       }
     } else {
-      const { code, stdout, stderr } = await exec('docker', { args: ['push', image] });
+      const { code, stderr } = await exec('docker', { args: ['push', image] });
 
       if (stderr && stderr.length > 0) {
         console.error(stderr);
         Deno.exit(code);
       }
     }
+
+    console.log(`Pushed image: ${image}`);
   }, async (deploymentName: string, volumeName: string, image: string, host_path: string, mount_path: string) => {
     const [name, version] = tag.split(':');
     const ref = `${name}/${deploymentName}/volume/${volumeName}:${version}`;
@@ -45,7 +47,7 @@ async function push_action(options: BuildOptions, tag: string): Promise<void> {
     );
     console.log(`Pushed Volume ${ref}`);
   });
-  console.log(`Pushed ${tag}`);
+  console.log(`Pushed component: ${tag}`);
 }
 
 export default PushCommand;

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,12 +1,15 @@
 import { verifyDocker } from '../docker/helper.ts';
-import { exec } from '../utils/command.ts';
+import { exec, execVerbose } from '../utils/command.ts';
 import { BaseCommand, CommandHelper, GlobalOptions } from './base-command.ts';
 
-type BuildOptions = GlobalOptions;
+type BuildOptions = {
+  verbose: boolean;
+} & GlobalOptions;
 
 const PushCommand = BaseCommand()
   .description('Push a component up to the registry')
   .arguments('<tag:string>')
+  .option('-v, --verbose [verbose:boolean]', 'Turn on verbose logs', { default: false })
   .action(push_action);
 
 async function push_action(options: BuildOptions, tag: string): Promise<void> {
@@ -15,7 +18,19 @@ async function push_action(options: BuildOptions, tag: string): Promise<void> {
 
   const component = await command_helper.componentStore.getComponentConfig(tag);
   await component.push(async (image: string) => {
-    await exec('docker', { args: ['push', image] });
+    if (options.verbose) {
+      const { code } = await execVerbose('docker', { args: ['push', image] });
+      if (code != 0) {
+        Deno.exit(code);
+      }
+    } else {
+      const { code, stdout, stderr } = await exec('docker', { args: ['push', image] });
+
+      if (stderr && stderr.length > 0) {
+        console.error(stderr);
+        Deno.exit(code);
+      }
+    }
   }, async (deploymentName: string, volumeName: string, image: string, host_path: string, mount_path: string) => {
     const [name, version] = tag.split(':');
     const ref = `${name}/${deploymentName}/volume/${volumeName}:${version}`;

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -47,7 +47,7 @@ async function push_action(options: BuildOptions, tag: string): Promise<void> {
     );
     console.log(`Pushed Volume ${ref}`);
   });
-  console.log(`Pushed component: ${tag}`);
+  console.log(`Pushed Component: ${tag}`);
 }
 
 export default PushCommand;

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'std/io/buffer.ts';
+
 export type ExecOutput = {
   code: number;
   stdout: string;
@@ -16,5 +18,48 @@ export async function exec(command: string, command_options: Deno.CommandOptions
     code,
     stdout: new TextDecoder().decode(stdout),
     stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+/**
+ * Execs the command and pipes stdout and stderr to Deno.stdout and Deno.stderr
+ * Returns the status code of the command.
+ */
+export async function execVerbose(command: string, command_options: Deno.CommandOptions): Promise<ExecOutput> {
+  const cmd = new Deno.Command(command, {
+    ...command_options,
+    stdout: 'piped',
+    stderr: 'piped',
+  });
+
+  const stdout = new Buffer();
+  const stderr = new Buffer();
+
+  const child = cmd.spawn();
+
+  child.stdout.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        stdout.writeSync(chunk);
+        Deno.stdout.writeSync(chunk);
+      },
+    }),
+  );
+
+  child.stderr.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        stderr.writeSync(chunk);
+        Deno.stderr.writeSync(chunk);
+      },
+    }),
+  );
+
+  const status = await child.status;
+
+  return {
+    code: status.code,
+    stdout: new TextDecoder().decode(stdout.bytes()),
+    stderr: new TextDecoder().decode(stderr.bytes()),
   };
 }


### PR DESCRIPTION
## Description

- Added a verbose mode to both the `build` and `push` commands
- Added `execVerbose` to pipe the stdout/err streams to the console when running docker commands.

Also fixed a couple bugs I found while testing:
- `disableOnDestroy: false` when using GCP APIs to prevent them from being turned off and breaking future pipeline calls (e.g. dnsRecord destroy will disable the DNS API, which then causes dnsZone deletion to fail)
- Kubernetes namespace terraform was passing the wrong value to the terraform stack and couldn't be created

Closes https://github.com/architect-team/arcctl/issues/105

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested and built the mailslurper component (https://github.com/architect-team/mailslurper), then deployed using the GCP kubernetes datacenter.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
