### PR TITLE
Added --var flag to apply datacenter command

### DIFF
--- a/src/commands/apply/datacenter.ts
+++ b/src/commands/apply/datacenter.ts
@@ -9,17 +9,33 @@ import { apply_environment_action } from './environment.ts';
 type ApplyDatacenterOptions = {
   verbose: boolean;
   autoApprove: boolean;
+  var?: string[];
 } & GlobalOptions;
 
 const ApplyDatacenterCommand = BaseCommand()
   .description('Create or update a datacenter')
   .option('-v, --verbose [verbose:boolean]', 'Verbose output', { default: false })
   .option('--auto-approve [autoApprove:boolean]', 'Skip all prompts and start the requested action', { default: false })
+  .option(
+    '--var <var:string>',
+    'Provide value for a datacenter variable - e.g. --var account=my-account-123 sets the `account` variable',
+    { collect: true },
+  )
   .arguments('<name:string> <config_path:string>')
   .action(apply_datacenter_action);
 
 async function apply_datacenter_action(options: ApplyDatacenterOptions, name: string, config_path: string) {
   const command_helper = new CommandHelper(options);
+
+  const flag_vars: Record<string, string> = {};
+  for (const v of options.var || []) {
+    const var_option = v.split('=');
+    if (var_option.length !== 2) {
+      console.log(`Invalid variable argument: '${v}'. Must be formatted: VAR_NAME=VAR_VALUE`);
+      Deno.exit(1);
+    }
+    flag_vars[var_option[0]] = var_option[1];
+  }
 
   const existingDatacenter = await command_helper.datacenterStore.get(name);
   const originalPipeline = existingDatacenter
@@ -32,7 +48,7 @@ async function apply_datacenter_action(options: ApplyDatacenterOptions, name: st
     const datacenter = await parseDatacenter(config_path);
 
     let graph = new CloudGraph();
-    const vars = await command_helper.promptForVariables(graph, datacenter.getVariables());
+    const vars = await command_helper.promptForVariables(graph, datacenter.getVariables(), flag_vars);
     datacenter.setVariableValues(vars);
     graph = await datacenter.enrichGraph(graph);
 

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -909,7 +909,7 @@ export class CommandHelper {
   public async promptForVariables(
     graph: CloudGraph,
     variables: ParsedVariablesType,
-    user_inputs?: Record<string, string>,
+    user_inputs: Record<string, string> = {},
   ): Promise<Record<string, unknown>> {
     const variable_inputs: Record<string, unknown> = {};
 
@@ -924,7 +924,7 @@ export class CommandHelper {
         graph,
         variable.name,
         variable.metadata,
-        user_inputs ? user_inputs[variable.name] : undefined,
+        user_inputs[variable.name],
       );
 
       variable_inputs[variable.name] = variable_value;


### PR DESCRIPTION
## Description

Adds the `--var FOO=value` flag to the `arcctl apply dc` command.

Closes https://github.com/architect-team/arcctl/issues/68

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```
$ arcctl apply dc gcp-k8s ./__tests__/datacenters/gcp.yml --var gcpAccount=gcp-test --var dnsZone=foobar.me --var region=us-east4-a
```

The above will create a GCP datacenter using an account named `gcp-test`, the dns zone `foobar.me`, and use the region `us-east4-a` for the VPC and other services that require a region.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
