### PR TITLE
Use docker credentials to pull and push with authenticated registries

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,26 @@
 {
   "version": "2",
   "remote": {
+    "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
+    "https://deno.land/std@0.140.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
+    "https://deno.land/std@0.140.0/bytes/bytes_list.ts": "67eb118e0b7891d2f389dad4add35856f4ad5faab46318ff99653456c23b025d",
+    "https://deno.land/std@0.140.0/bytes/equals.ts": "fc16dff2090cced02497f16483de123dfa91e591029f985029193dfaa9d894c9",
+    "https://deno.land/std@0.140.0/bytes/mod.ts": "763f97d33051cc3f28af1a688dfe2830841192a9fea0cbaa55f927b49d49d0bf",
+    "https://deno.land/std@0.140.0/fmt/colors.ts": "30455035d6d728394781c10755351742dd731e3db6771b1843f9b9e490104d37",
+    "https://deno.land/std@0.140.0/fs/_util.ts": "0fb24eb4bfebc2c194fb1afdb42b9c3dda12e368f43e8f2321f84fc77d42cb0f",
+    "https://deno.land/std@0.140.0/fs/ensure_dir.ts": "9dc109c27df4098b9fc12d949612ae5c9c7169507660dcf9ad90631833209d9d",
+    "https://deno.land/std@0.140.0/hash/sha256.ts": "803846c7a5a8a5a97f31defeb37d72f519086c880837129934f5d6f72102a8e8",
+    "https://deno.land/std@0.140.0/io/buffer.ts": "bd0c4bf53db4b4be916ca5963e454bddfd3fcd45039041ea161dbf826817822b",
+    "https://deno.land/std@0.140.0/path/_constants.ts": "df1db3ffa6dd6d1252cc9617e5d72165cd2483df90e93833e13580687b6083c3",
+    "https://deno.land/std@0.140.0/path/_interface.ts": "ee3b431a336b80cf445441109d089b70d87d5e248f4f90ff906820889ecf8d09",
+    "https://deno.land/std@0.140.0/path/_util.ts": "c1e9686d0164e29f7d880b2158971d805b6e0efc3110d0b3e24e4b8af2190d2b",
+    "https://deno.land/std@0.140.0/path/common.ts": "bee563630abd2d97f99d83c96c2fa0cca7cee103e8cb4e7699ec4d5db7bd2633",
+    "https://deno.land/std@0.140.0/path/glob.ts": "cb5255638de1048973c3e69e420c77dc04f75755524cb3b2e160fe9277d939ee",
+    "https://deno.land/std@0.140.0/path/mod.ts": "d3e68d0abb393fb0bf94a6d07c46ec31dc755b544b13144dee931d8d5f06a52d",
+    "https://deno.land/std@0.140.0/path/posix.ts": "293cdaec3ecccec0a9cc2b534302dfe308adb6f10861fa183275d6695faace44",
+    "https://deno.land/std@0.140.0/path/separator.ts": "fe1816cb765a8068afb3e8f13ad272351c85cbc739af56dacfc7d93d710fe0f9",
+    "https://deno.land/std@0.140.0/path/win32.ts": "31811536855e19ba37a999cd8d1b62078235548d67902ece4aa6b814596dd757",
+    "https://deno.land/std@0.140.0/streams/conversion.ts": "712585bfa0172a97fb68dd46e784ae8ad59d11b88079d6a4ab098ff42e697d21",
     "https://deno.land/std@0.153.0/_deno_unstable.ts": "4ddb8672d49d58b5bbc4a5a7a2f1b3bce4fd06aa4c8b8476728334391667de7b",
     "https://deno.land/std@0.153.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.153.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
@@ -290,6 +310,10 @@
     "https://deno.land/std@0.181.0/bytes/repeat.ts": "6f5e490d8d72bcbf8d84a6bb04690b9b3eb5822c5a11687bca73a2318a842294",
     "https://deno.land/std@0.181.0/bytes/starts_with.ts": "3e607a70c9c09f5140b7a7f17a695221abcc7244d20af3eb47ccbb63f5885135",
     "https://deno.land/std@0.181.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.181.0/fs/_util.ts": "65381f341af1ff7f40198cee15c20f59951ac26e51ddc651c5293e24f9ce6f32",
+    "https://deno.land/std@0.181.0/fs/ensure_dir.ts": "dc64c4c75c64721d4e3fb681f1382f803ff3d2868f08563ff923fdd20d071c40",
+    "https://deno.land/std@0.181.0/fs/expand_glob.ts": "e4f56259a0a70fe23f05215b00de3ac5e6ba46646ab2a06ebbe9b010f81c972a",
+    "https://deno.land/std@0.181.0/fs/walk.ts": "ea95ffa6500c1eda6b365be488c056edc7c883a1db41ef46ec3bf057b1c0fe32",
     "https://deno.land/std@0.181.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
     "https://deno.land/std@0.181.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
     "https://deno.land/std@0.181.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
@@ -302,6 +326,22 @@
     "https://deno.land/std@0.181.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
     "https://deno.land/std@0.181.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
     "https://deno.land/std@0.181.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
+    "https://deno.land/std@0.182.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
+    "https://deno.land/std@0.182.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
+    "https://deno.land/std@0.182.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
+    "https://deno.land/std@0.182.0/fs/_util.ts": "65381f341af1ff7f40198cee15c20f59951ac26e51ddc651c5293e24f9ce6f32",
+    "https://deno.land/std@0.182.0/fs/empty_dir.ts": "c3d2da4c7352fab1cf144a1ecfef58090769e8af633678e0f3fabaef98594688",
+    "https://deno.land/std@0.182.0/fs/expand_glob.ts": "e4f56259a0a70fe23f05215b00de3ac5e6ba46646ab2a06ebbe9b010f81c972a",
+    "https://deno.land/std@0.182.0/fs/walk.ts": "920be35a7376db6c0b5b1caf1486fb962925e38c9825f90367f8f26b5e5d0897",
+    "https://deno.land/std@0.182.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.182.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
+    "https://deno.land/std@0.182.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
+    "https://deno.land/std@0.182.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
+    "https://deno.land/std@0.182.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
+    "https://deno.land/std@0.182.0/path/mod.ts": "bf718f19a4fdd545aee1b06409ca0805bd1b68ecf876605ce632e932fe54510c",
+    "https://deno.land/std@0.182.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
+    "https://deno.land/std@0.182.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
+    "https://deno.land/std@0.182.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
     "https://deno.land/std@0.190.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
     "https://deno.land/std@0.190.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
     "https://deno.land/std@0.190.0/io/buffer.ts": "17f4410eaaa60a8a85733e8891349a619eadfbbe42e2f319283ce2b8f29723ab",
@@ -394,7 +434,22 @@
     "https://deno.land/std@0.192.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
     "https://deno.land/std@0.192.0/testing/bdd.ts": "59f7f7503066d66a12e50ace81bfffae5b735b6be1208f5684b630ae6b4de1d0",
     "https://deno.land/std@0.192.0/testing/mock.ts": "220ed9b8151cb2cac141043d4cfea7c47673fab5d18d1c1f0943297c8afb5d13",
+    "https://deno.land/std@0.195.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
+    "https://deno.land/std@0.195.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.195.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
     "https://deno.land/std@0.195.0/encoding/base64.ts": "144ae6234c1fbe5b68666c711dc15b1e9ee2aef6d42b3b4345bf9a6c91d70d0d",
+    "https://deno.land/std@0.195.0/fs/_util.ts": "fbf57dcdc9f7bc8128d60301eece608246971a7836a3bb1e78da75314f08b978",
+    "https://deno.land/std@0.195.0/fs/copy.ts": "b4f7fe87190d7b310c88a2d9ff845210c0a2b7b0a094ec509747359023beb7d6",
+    "https://deno.land/std@0.195.0/fs/ensure_dir.ts": "dc64c4c75c64721d4e3fb681f1382f803ff3d2868f08563ff923fdd20d071c40",
+    "https://deno.land/std@0.195.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.195.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
+    "https://deno.land/std@0.195.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
+    "https://deno.land/std@0.195.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
+    "https://deno.land/std@0.195.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
+    "https://deno.land/std@0.195.0/path/mod.ts": "f065032a7189404fdac3ad1a1551a9ac84751d2f25c431e101787846c86c79ef",
+    "https://deno.land/std@0.195.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
+    "https://deno.land/std@0.195.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
+    "https://deno.land/std@0.195.0/path/win32.ts": "4fca292f8d116fd6d62f243b8a61bd3d6835a9f0ede762ba5c01afe7c3c0aa12",
     "https://deno.land/std@0.80.0/encoding/base64.ts": "b1d8f99b778981548457ec74bc6273ad785ffd6f61b2233bd5b30925345b565d",
     "https://deno.land/std@0.80.0/encoding/hex.ts": "07a03ba41c96060a4ed4ba272e50b9e23f3c5b3839f4b069cdebc24d57434386",
     "https://deno.land/std@0.80.0/hash/_wasm/hash.ts": "005f64c4d9343ecbc91e0da9ae5e800f146c20930ad829bbb872c5c06bd89c5f",
@@ -479,10 +534,44 @@
     "https://deno.land/x/cliffy@v0.25.7/table/row.ts": "5f519ba7488d2ef76cbbf50527f10f7957bfd668ce5b9169abbc44ec88302645",
     "https://deno.land/x/cliffy@v0.25.7/table/table.ts": "ec204c9d08bb3ff1939c5ac7412a4c9ed7d00925d4fc92aff9bfe07bd269258d",
     "https://deno.land/x/cliffy@v0.25.7/table/utils.ts": "187bb7dcbcfb16199a5d906113f584740901dfca1007400cba0df7dcd341bc29",
+    "https://deno.land/x/code_block_writer@12.0.0/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",
+    "https://deno.land/x/code_block_writer@12.0.0/utils/string_utils.ts": "60cb4ec8bd335bf241ef785ccec51e809d576ff8e8d29da43d2273b69ce2a6ff",
+    "https://deno.land/x/deno_cache@0.4.1/auth_tokens.ts": "5fee7e9155e78cedf3f6ff3efacffdb76ac1a76c86978658d9066d4fb0f7326e",
+    "https://deno.land/x/deno_cache@0.4.1/cache.ts": "51f72f4299411193d780faac8c09d4e8cbee951f541121ef75fcc0e94e64c195",
+    "https://deno.land/x/deno_cache@0.4.1/deno_dir.ts": "f2a9044ce8c7fe1109004cda6be96bf98b08f478ce77e7a07f866eff1bdd933f",
+    "https://deno.land/x/deno_cache@0.4.1/deps.ts": "8974097d6c17e65d9a82d39377ae8af7d94d74c25c0cbb5855d2920e063f2343",
+    "https://deno.land/x/deno_cache@0.4.1/dirs.ts": "d2fa473ef490a74f2dcb5abb4b9ab92a48d2b5b6320875df2dee64851fa64aa9",
+    "https://deno.land/x/deno_cache@0.4.1/disk_cache.ts": "1f3f5232cba4c56412d93bdb324c624e95d5dd179d0578d2121e3ccdf55539f9",
+    "https://deno.land/x/deno_cache@0.4.1/file_fetcher.ts": "07a6c5f8fd94bf50a116278cc6012b4921c70d2251d98ce1c9f3c352135c39f7",
+    "https://deno.land/x/deno_cache@0.4.1/http_cache.ts": "f632e0d6ec4a5d61ae3987737a72caf5fcdb93670d21032ddb78df41131360cd",
+    "https://deno.land/x/deno_cache@0.4.1/mod.ts": "ef1cda9235a93b89cb175fe648372fc0f785add2a43aa29126567a05e3e36195",
+    "https://deno.land/x/deno_cache@0.4.1/util.ts": "8cb686526f4be5205b92c819ca2ce82220aa0a8dd3613ef0913f6dc269dbbcfe",
     "https://deno.land/x/dir@1.5.1/home_dir/mod.ts": "53777e4fb2586ae02ce94adf2c99f2edb2dcf6e72d07ac289b71593cfacbdbbf",
+    "https://deno.land/x/dnt@0.36.0/lib/compiler.ts": "209ad2e1b294f93f87ec02ade9a0821f942d2e524104552d0aa8ff87021050a5",
+    "https://deno.land/x/dnt@0.36.0/lib/compiler_transforms.ts": "cbb1fd5948f5ced1aa5c5aed9e45134e2357ce1e7220924c1d7bded30dcd0dd0",
+    "https://deno.land/x/dnt@0.36.0/lib/mod.deps.ts": "30367fc68bcd2acf3b7020cf5cdd26f817f7ac9ac35c4bfb6c4551475f91bc3e",
+    "https://deno.land/x/dnt@0.36.0/lib/npm_ignore.ts": "b430caa1905b65ae89b119d84857b3ccc3cb783a53fc083d1970e442f791721d",
+    "https://deno.land/x/dnt@0.36.0/lib/package_json.ts": "61f35b06e374ed39ca776d29d67df4be7ee809d0bca29a8239687556c6d027c2",
+    "https://deno.land/x/dnt@0.36.0/lib/pkg/dnt_wasm.generated.js": "1f21e46f32209d8746fd5c7d3bc8f25c2cbebe1d9da4ef083eca1b621eb72598",
+    "https://deno.land/x/dnt@0.36.0/lib/pkg/snippets/dnt-wasm-a15ef721fa5290c5/helpers.js": "a6b95adc943a68d513fe8ed9ec7d260ac466b7a4bced4e942f733e494bb9f1be",
+    "https://deno.land/x/dnt@0.36.0/lib/shims.ts": "df1bd4d9a196dca4b2d512b1564fff64ac6c945189a273d706391f87f210d7e6",
+    "https://deno.land/x/dnt@0.36.0/lib/test_runner/get_test_runner_code.ts": "4dc7a73a13b027341c0688df2b29a4ef102f287c126f134c33f69f0339b46968",
+    "https://deno.land/x/dnt@0.36.0/lib/test_runner/test_runner.ts": "4d0da0500ec427d5f390d9a8d42fb882fbeccc92c92d66b6f2e758606dbd40e6",
+    "https://deno.land/x/dnt@0.36.0/lib/transform.deps.ts": "e42f2bdef46d098453bdba19261a67cf90b583f5d868f7fe83113c1380d9b85c",
+    "https://deno.land/x/dnt@0.36.0/lib/types.ts": "b8e228b2fac44c2ae902fbb73b1689f6ab889915bd66486c8a85c0c24255f5fb",
+    "https://deno.land/x/dnt@0.36.0/lib/utils.ts": "878b7ac7003a10c16e6061aa49dbef9b42bd43174853ebffc9b67ea47eeb11d8",
+    "https://deno.land/x/dnt@0.36.0/mod.ts": "670f1820f2115e6b6aa4f79999bc796e30cc0d0b45096b84a4e1db9f62b82984",
+    "https://deno.land/x/dnt@0.36.0/transform.ts": "1b127c5f22699c8ab2545b98aeca38c4e5c21405b0f5342ea17e9c46280ed277",
     "https://deno.land/x/mock_file@v1.1.2/mod.ts": "57b111ba84b5611c09ed82ef300dd063eb278ef68bd286d5149e5b018eb8948d",
     "https://deno.land/x/mock_file@v1.1.2/src/memory_file.ts": "24817e782c819cdfb48b9459dc8ad568e8fb2cd2934cd5b775688147e6dc4cbd",
     "https://deno.land/x/mock_file@v1.1.2/src/polyfill.ts": "f10f05ec2493cb1e029b30cd211a21803b7683d811813d519696aa2939529b35",
+    "https://deno.land/x/ts_morph@18.0.0/bootstrap/mod.ts": "b53aad517f106c4079971fcd4a81ab79fadc40b50061a3ab2b741a09119d51e9",
+    "https://deno.land/x/ts_morph@18.0.0/bootstrap/ts_morph_bootstrap.js": "6645ac03c5e6687dfa8c78109dc5df0250b811ecb3aea2d97c504c35e8401c06",
+    "https://deno.land/x/ts_morph@18.0.0/common/DenoRuntime.ts": "6a7180f0c6e90dcf23ccffc86aa8271c20b1c4f34c570588d08a45880b7e172d",
+    "https://deno.land/x/ts_morph@18.0.0/common/mod.ts": "01985d2ee7da8d1caee318a9d07664774fbee4e31602bc2bb6bb62c3489555ed",
+    "https://deno.land/x/ts_morph@18.0.0/common/ts_morph_common.js": "845671ca951073400ce142f8acefa2d39ea9a51e29ca80928642f3f8cf2b7700",
+    "https://deno.land/x/ts_morph@18.0.0/common/typescript.js": "d5c598b6a2db2202d0428fca5fd79fc9a301a71880831a805d778797d2413c59",
+    "https://esm.sh/mustache@4.2.0": "da4f1d45c3fec1e78a516e6ce01ab4582ffc5b868ace8a244cc640fc25282c60",
     "https://esm.sh/v124/*log-update@5.0.1": "49199324effae77a660f21ea75937847315fdb5f67a86881496717314bb95b2a",
     "https://esm.sh/v124/@colors/colors@1.5.0/denonext/safe.js": "0ac89c10d0d3772a939e427ec2ec8d5c98a2ea06f3e37dfbf73a34f22789d9bc",
     "https://esm.sh/v124/@dabh/diagnostics@2.0.3/denonext/diagnostics.mjs": "5dc113c079ceab4bf26f73d838462de298f2ffaf74fd14309ed1f8afb208c2af",
@@ -687,18 +776,29 @@
     "https://esm.sh/v124/winston@3.8.2/denonext/winston.mjs": "cd88f004dd09908a782d94ea6a56691b0092ef74dcc842fd720bf70c3d3d4a58",
     "https://esm.sh/v124/wrap-ansi@8.1.0": "da576a84619b45bf324bfb582b74f3c38b23deb5abb204d3b3aca329f6cd970d",
     "https://esm.sh/v124/wrap-ansi@8.1.0/denonext/wrap-ansi.mjs": "1804d60795c6034323e4b8dc92425aa9ab28385b87bb700772e16cb92bb0d8f8",
-    "https://esm.sh/v124/yallist@4.0.0/denonext/yallist.mjs": "61f180d807dda50bac17028eda05d5722a3fecef6e98a9064e2353ea6864fd82"
+    "https://esm.sh/v124/yallist@4.0.0/denonext/yallist.mjs": "61f180d807dda50bac17028eda05d5722a3fecef6e98a9064e2353ea6864fd82",
+    "https://esm.sh/v128/mustache@4.2.0/denonext/mustache.mjs": "8c046aa4755b9beb2f203e01fdab7d36e4c75dd1bc22021be44ac31723ead9f0"
   },
   "npm": {
     "specifiers": {
-      "@types/pg@^8.6.5": "@types/pg@8.10.2",
       "@types/node": "@types/node@18.16.18",
+      "@types/pg@^8.6.5": "@types/pg@8.10.2",
       "aws-sdk@2.1229.0": "aws-sdk@2.1229.0",
-      "pg@8.8.0": "pg@8.8.0"
+      "mustache": "mustache@4.2.0",
+      "pg@8.8.0": "pg@8.8.0",
+      "ts-json-schema-generator": "ts-json-schema-generator@1.2.0"
     },
     "packages": {
+      "@types/json-schema@7.0.12": {
+        "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+        "dependencies": {}
+      },
       "@types/node@18.16.17": {
         "integrity": "sha512-QAkjjRA1N7gPJeAP4WLXZtYv6+eMXFNviqktCDt4GLcmCugMr5BcRHfkOjCQzvCsnMp+L79a54zBkbw356xv9Q==",
+        "dependencies": {}
+      },
+      "@types/node@18.16.18": {
+        "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
         "dependencies": {}
       },
       "@types/node@20.3.0": {
@@ -712,10 +812,6 @@
           "pg-protocol": "pg-protocol@1.6.0",
           "pg-types": "pg-types@4.0.1"
         }
-      },
-      "@types/node@18.16.18": {
-        "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
-        "dependencies": {}
       },
       "available-typed-arrays@1.0.5": {
         "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
@@ -736,9 +832,19 @@
           "xml2js": "xml2js@0.4.19"
         }
       },
+      "balanced-match@1.0.2": {
+        "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+        "dependencies": {}
+      },
       "base64-js@1.5.1": {
         "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
         "dependencies": {}
+      },
+      "brace-expansion@2.0.1": {
+        "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+        "dependencies": {
+          "balanced-match": "balanced-match@1.0.2"
+        }
       },
       "buffer-writer@2.0.0": {
         "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
@@ -759,6 +865,10 @@
           "get-intrinsic": "get-intrinsic@1.2.1"
         }
       },
+      "commander@9.5.0": {
+        "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+        "dependencies": {}
+      },
       "events@1.1.1": {
         "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
         "dependencies": {}
@@ -768,6 +878,10 @@
         "dependencies": {
           "is-callable": "is-callable@1.2.7"
         }
+      },
+      "fs.realpath@1.0.0": {
+        "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+        "dependencies": {}
       },
       "function-bind@1.1.1": {
         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
@@ -780,6 +894,16 @@
           "has": "has@1.0.3",
           "has-proto": "has-proto@1.0.1",
           "has-symbols": "has-symbols@1.0.3"
+        }
+      },
+      "glob@8.1.0": {
+        "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+        "dependencies": {
+          "fs.realpath": "fs.realpath@1.0.0",
+          "inflight": "inflight@1.0.6",
+          "inherits": "inherits@2.0.4",
+          "minimatch": "minimatch@5.1.6",
+          "once": "once@1.4.0"
         }
       },
       "gopd@1.0.1": {
@@ -811,6 +935,13 @@
       "ieee754@1.1.13": {
         "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
         "dependencies": {}
+      },
+      "inflight@1.0.6": {
+        "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+        "dependencies": {
+          "once": "once@1.4.0",
+          "wrappy": "wrappy@1.0.2"
+        }
       },
       "inherits@2.0.4": {
         "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
@@ -851,9 +982,33 @@
         "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
         "dependencies": {}
       },
+      "json5@2.2.3": {
+        "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+        "dependencies": {}
+      },
+      "minimatch@5.1.6": {
+        "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+        "dependencies": {
+          "brace-expansion": "brace-expansion@2.0.1"
+        }
+      },
+      "mustache@4.2.0": {
+        "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+        "dependencies": {}
+      },
+      "normalize-path@3.0.0": {
+        "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+        "dependencies": {}
+      },
       "obuf@1.1.2": {
         "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
         "dependencies": {}
+      },
+      "once@1.4.0": {
+        "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+        "dependencies": {
+          "wrappy": "wrappy@1.0.2"
+        }
       },
       "packet-reader@1.0.0": {
         "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
@@ -969,12 +1124,32 @@
         "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
         "dependencies": {}
       },
+      "safe-stable-stringify@2.4.3": {
+        "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+        "dependencies": {}
+      },
       "sax@1.2.1": {
         "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
         "dependencies": {}
       },
       "split2@4.2.0": {
         "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+        "dependencies": {}
+      },
+      "ts-json-schema-generator@1.2.0": {
+        "integrity": "sha512-tUMeO3ZvA12d3HHh7T/AK8W5hmUhDRNtqWRHSMN3ZRbUFt+UmV0oX8k1RK4SA+a+BKNHpmW2v06MS49e8Fi3Yg==",
+        "dependencies": {
+          "@types/json-schema": "@types/json-schema@7.0.12",
+          "commander": "commander@9.5.0",
+          "glob": "glob@8.1.0",
+          "json5": "json5@2.2.3",
+          "normalize-path": "normalize-path@3.0.0",
+          "safe-stable-stringify": "safe-stable-stringify@2.4.3",
+          "typescript": "typescript@4.9.5"
+        }
+      },
+      "typescript@4.9.5": {
+        "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
         "dependencies": {}
       },
       "url@0.10.3": {
@@ -1008,6 +1183,10 @@
           "has-tostringtag": "has-tostringtag@1.0.0",
           "is-typed-array": "is-typed-array@1.1.10"
         }
+      },
+      "wrappy@1.0.2": {
+        "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+        "dependencies": {}
       },
       "xml2js@0.4.19": {
         "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",

--- a/deno.lock
+++ b/deno.lock
@@ -394,6 +394,7 @@
     "https://deno.land/std@0.192.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
     "https://deno.land/std@0.192.0/testing/bdd.ts": "59f7f7503066d66a12e50ace81bfffae5b735b6be1208f5684b630ae6b4de1d0",
     "https://deno.land/std@0.192.0/testing/mock.ts": "220ed9b8151cb2cac141043d4cfea7c47673fab5d18d1c1f0943297c8afb5d13",
+    "https://deno.land/std@0.195.0/encoding/base64.ts": "144ae6234c1fbe5b68666c711dc15b1e9ee2aef6d42b3b4345bf9a6c91d70d0d",
     "https://deno.land/std@0.80.0/encoding/base64.ts": "b1d8f99b778981548457ec74bc6273ad785ffd6f61b2233bd5b30925345b565d",
     "https://deno.land/std@0.80.0/encoding/hex.ts": "07a03ba41c96060a4ed4ba272e50b9e23f3c5b3839f4b069cdebc24d57434386",
     "https://deno.land/std@0.80.0/hash/_wasm/hash.ts": "005f64c4d9343ecbc91e0da9ae5e800f146c20930ad829bbb872c5c06bd89c5f",
@@ -690,8 +691,8 @@
   },
   "npm": {
     "specifiers": {
-      "@types/node": "@types/node@18.16.17",
       "@types/pg@^8.6.5": "@types/pg@8.10.2",
+      "@types/node": "@types/node@18.16.18",
       "aws-sdk@2.1229.0": "aws-sdk@2.1229.0",
       "pg@8.8.0": "pg@8.8.0"
     },
@@ -711,6 +712,10 @@
           "pg-protocol": "pg-protocol@1.6.0",
           "pg-types": "pg-types@4.0.1"
         }
+      },
+      "@types/node@18.16.18": {
+        "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
+        "dependencies": {}
       },
       "available-typed-arrays@1.0.5": {
         "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",

--- a/import_map.json
+++ b/import_map.json
@@ -22,7 +22,8 @@
     "which": "https://esm.sh/v124/which@3.0.1",
     "winston": "https://esm.sh/v124/winston@3.8.2",
     "@kubernetes/client-node": "npm:@kubernetes/client-node@0.18.1",
-    "aws-sdk": "npm:aws-sdk@2.1229.0"
+    "aws-sdk": "npm:aws-sdk@2.1229.0",
+    "mustache": "https://esm.sh/mustache@4.2.0"
   },
   "scopes": {
     "https://esm.sh/v124/": {

--- a/src/@resources/deployment/inputs.schema.json
+++ b/src/@resources/deployment/inputs.schema.json
@@ -250,7 +250,7 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
-                    "local_image": {
+                    "image": {
                       "type": "string"
                     },
                     "mount_path": {
@@ -258,9 +258,6 @@
                     },
                     "readonly": {
                       "type": "boolean"
-                    },
-                    "remote_image": {
-                      "type": "string"
                     },
                     "volume": {
                       "type": "string"
@@ -289,7 +286,7 @@
           "items": {
             "additionalProperties": false,
             "properties": {
-              "local_image": {
+              "image": {
                 "type": "string"
               },
               "mount_path": {
@@ -297,9 +294,6 @@
               },
               "readonly": {
                 "type": "boolean"
-              },
-              "remote_image": {
-                "type": "string"
               },
               "volume": {
                 "type": "string"

--- a/src/@resources/deployment/inputs.ts
+++ b/src/@resources/deployment/inputs.ts
@@ -115,8 +115,7 @@ type Container = {
   volume_mounts: Array<{
     volume: string;
     mount_path: string;
-    local_image?: string;
-    remote_image?: string;
+    image?: string;
     readonly: boolean;
   }>;
 

--- a/src/@resources/input-schema.ts
+++ b/src/@resources/input-schema.ts
@@ -248,6 +248,52 @@ export default {
               'account': {
                 'type': 'string',
               },
+              'databaseCluster': {
+                'description': 'Unique ID of the database cluster backing this schema',
+                'type': 'string',
+              },
+              'databaseType': {
+                'description': 'Type of database required by the schema',
+                'type': 'string',
+              },
+              'databaseVersion': {
+                'description': 'Version of the database type the schema creation process expects',
+                'type': 'string',
+              },
+              'name': {
+                'description': 'Name to give to the new schema',
+                'type': 'string',
+              },
+              'type': {
+                'const': 'database',
+                'type': 'string',
+              },
+            },
+            'required': [
+              'databaseCluster',
+              'databaseType',
+              'databaseVersion',
+              'name',
+              'type',
+            ],
+            'type': 'object',
+          },
+        },
+        {
+          'if': {
+            'properties': {
+              'type': {
+                'const': 'databaseCluster',
+                'type': 'string',
+              },
+            },
+          },
+          'then': {
+            'additionalProperties': false,
+            'properties': {
+              'account': {
+                'type': 'string',
+              },
               'databaseSize': {
                 'description': 'Size of the database instance to create',
                 'type': 'string',
@@ -273,7 +319,7 @@ export default {
                 'type': 'string',
               },
               'type': {
-                'const': 'database',
+                'const': 'databaseCluster',
                 'type': 'string',
               },
               'vpc': {
@@ -289,52 +335,6 @@ export default {
               'region',
               'type',
               'vpc',
-            ],
-            'type': 'object',
-          },
-        },
-        {
-          'if': {
-            'properties': {
-              'type': {
-                'const': 'databaseSchema',
-                'type': 'string',
-              },
-            },
-          },
-          'then': {
-            'additionalProperties': false,
-            'properties': {
-              'account': {
-                'type': 'string',
-              },
-              'database': {
-                'description': 'Unique ID of the database backing this schema',
-                'type': 'string',
-              },
-              'databaseType': {
-                'description': 'Type of database required by the schema',
-                'type': 'string',
-              },
-              'databaseVersion': {
-                'description': 'Version of the database type the schema creation process expects',
-                'type': 'string',
-              },
-              'name': {
-                'description': 'Name to give to the new schema',
-                'type': 'string',
-              },
-              'type': {
-                'const': 'databaseSchema',
-                'type': 'string',
-              },
-            },
-            'required': [
-              'database',
-              'databaseType',
-              'databaseVersion',
-              'name',
-              'type',
             ],
             'type': 'object',
           },
@@ -406,8 +406,8 @@ export default {
               'account': {
                 'type': 'string',
               },
-              'databaseSchema': {
-                'description': 'The schema the user should have access to',
+              'database': {
+                'description': 'The database the user should have access to',
                 'type': 'string',
               },
               'type': {
@@ -420,7 +420,7 @@ export default {
               },
             },
             'required': [
-              'databaseSchema',
+              'database',
               'type',
               'username',
             ],
@@ -561,7 +561,6 @@ export default {
                     },
                   },
                   'required': [
-                    'port',
                     'target_port',
                   ],
                   'type': 'object',
@@ -622,10 +621,15 @@ export default {
                       'description': 'Unique ID of the service the deployment should attach itself to',
                       'type': 'string',
                     },
+                    'port': {
+                      'description': 'The port the service deployment is listening on',
+                      'type': 'string',
+                    },
                   },
                   'required': [
                     'id',
                     'account',
+                    'port',
                   ],
                   'type': 'object',
                 },
@@ -714,7 +718,7 @@ export default {
                       'items': {
                         'additionalProperties': false,
                         'properties': {
-                          'local_image': {
+                          'image': {
                             'type': 'string',
                           },
                           'mount_path': {
@@ -722,9 +726,6 @@ export default {
                           },
                           'readonly': {
                             'type': 'boolean',
-                          },
-                          'remote_image': {
-                            'type': 'string',
                           },
                           'volume': {
                             'type': 'string',
@@ -757,7 +758,7 @@ export default {
                 'items': {
                   'additionalProperties': false,
                   'properties': {
-                    'local_image': {
+                    'image': {
                       'type': 'string',
                     },
                     'mount_path': {
@@ -765,9 +766,6 @@ export default {
                     },
                     'readonly': {
                       'type': 'boolean',
-                    },
-                    'remote_image': {
-                      'type': 'string',
                     },
                     'volume': {
                       'type': 'string',
@@ -1392,12 +1390,8 @@ export default {
                 'description': 'Basic auth password',
                 'type': 'string',
               },
-              'port': {
-                'description': 'Port to listen on',
-                'type': 'number',
-              },
               'target_deployment': {
-                'description': 'Target deployment name',
+                'description': 'A deployment the service should point to',
                 'type': 'string',
               },
               'target_port': {
@@ -1408,6 +1402,13 @@ export default {
                 'default': 'http',
                 'description': 'Protocol',
                 'type': 'string',
+              },
+              'target_servers': {
+                'description': 'The servers the service should load balance between',
+                'items': {
+                  'type': 'string',
+                },
+                'type': 'array',
               },
               'type': {
                 'const': 'service',
@@ -1420,7 +1421,6 @@ export default {
             },
             'required': [
               'name',
-              'target_deployment',
               'target_port',
               'type',
             ],
@@ -1683,7 +1683,7 @@ export default {
             'arcctlAccount',
             'cronjob',
             'database',
-            'databaseSchema',
+            'databaseCluster',
             'databaseUser',
             'databaseVersion',
             'deployment',

--- a/src/@resources/input.schema.json
+++ b/src/@resources/input.schema.json
@@ -718,7 +718,7 @@
                       "items": {
                         "additionalProperties": false,
                         "properties": {
-                          "local_image": {
+                          "image": {
                             "type": "string"
                           },
                           "mount_path": {
@@ -726,9 +726,6 @@
                           },
                           "readonly": {
                             "type": "boolean"
-                          },
-                          "remote_image": {
-                            "type": "string"
                           },
                           "volume": {
                             "type": "string"
@@ -761,7 +758,7 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
-                    "local_image": {
+                    "image": {
                       "type": "string"
                     },
                     "mount_path": {
@@ -769,9 +766,6 @@
                     },
                     "readonly": {
                       "type": "boolean"
-                    },
-                    "remote_image": {
-                      "type": "string"
                     },
                     "volume": {
                       "type": "string"

--- a/src/@resources/inputs-schema.ts
+++ b/src/@resources/inputs-schema.ts
@@ -207,6 +207,40 @@ export default {
       'DatabaseApplyInputs': {
         'additionalProperties': false,
         'properties': {
+          'databaseCluster': {
+            'description': 'Unique ID of the database cluster backing this schema',
+            'type': 'string',
+          },
+          'databaseType': {
+            'description': 'Type of database required by the schema',
+            'type': 'string',
+          },
+          'databaseVersion': {
+            'description': 'Version of the database type the schema creation process expects',
+            'type': 'string',
+          },
+          'name': {
+            'description': 'Name to give to the new schema',
+            'type': 'string',
+          },
+        },
+        'required': [
+          'name',
+          'databaseCluster',
+          'databaseType',
+          'databaseVersion',
+        ],
+        'type': 'object',
+      },
+    },
+  },
+  'databaseCluster': {
+    '$ref': '#/definitions/DatabaseClusterApplyInputs',
+    '$schema': 'http://json-schema.org/draft-07/schema#',
+    'definitions': {
+      'DatabaseClusterApplyInputs': {
+        'additionalProperties': false,
+        'properties': {
           'databaseSize': {
             'description': 'Size of the database instance to create',
             'type': 'string',
@@ -248,40 +282,6 @@ export default {
       },
     },
   },
-  'databaseSchema': {
-    '$ref': '#/definitions/DatabaseSchemaInputs',
-    '$schema': 'http://json-schema.org/draft-07/schema#',
-    'definitions': {
-      'DatabaseSchemaInputs': {
-        'additionalProperties': false,
-        'properties': {
-          'database': {
-            'description': 'Unique ID of the database backing this schema',
-            'type': 'string',
-          },
-          'databaseType': {
-            'description': 'Type of database required by the schema',
-            'type': 'string',
-          },
-          'databaseVersion': {
-            'description': 'Version of the database type the schema creation process expects',
-            'type': 'string',
-          },
-          'name': {
-            'description': 'Name to give to the new schema',
-            'type': 'string',
-          },
-        },
-        'required': [
-          'name',
-          'database',
-          'databaseType',
-          'databaseVersion',
-        ],
-        'type': 'object',
-      },
-    },
-  },
   'databaseSize': {
     '$ref': '#/definitions/DatabaseSizeInputs',
     '$schema': 'http://json-schema.org/draft-07/schema#',
@@ -309,8 +309,8 @@ export default {
       'DatabaseUserApplyInputs': {
         'additionalProperties': false,
         'properties': {
-          'databaseSchema': {
-            'description': 'The schema the user should have access to',
+          'database': {
+            'description': 'The database the user should have access to',
             'type': 'string',
           },
           'username': {
@@ -320,7 +320,7 @@ export default {
         },
         'required': [
           'username',
-          'databaseSchema',
+          'database',
         ],
         'type': 'object',
       },
@@ -439,7 +439,6 @@ export default {
                 },
               },
               'required': [
-                'port',
                 'target_port',
               ],
               'type': 'object',
@@ -500,10 +499,15 @@ export default {
                   'description': 'Unique ID of the service the deployment should attach itself to',
                   'type': 'string',
                 },
+                'port': {
+                  'description': 'The port the service deployment is listening on',
+                  'type': 'string',
+                },
               },
               'required': [
                 'id',
                 'account',
+                'port',
               ],
               'type': 'object',
             },
@@ -592,7 +596,7 @@ export default {
                   'items': {
                     'additionalProperties': false,
                     'properties': {
-                      'local_image': {
+                      'image': {
                         'type': 'string',
                       },
                       'mount_path': {
@@ -600,9 +604,6 @@ export default {
                       },
                       'readonly': {
                         'type': 'boolean',
-                      },
-                      'remote_image': {
-                        'type': 'string',
                       },
                       'volume': {
                         'type': 'string',
@@ -631,7 +632,7 @@ export default {
             'items': {
               'additionalProperties': false,
               'properties': {
-                'local_image': {
+                'image': {
                   'type': 'string',
                 },
                 'mount_path': {
@@ -639,9 +640,6 @@ export default {
                 },
                 'readonly': {
                   'type': 'boolean',
-                },
-                'remote_image': {
-                  'type': 'string',
                 },
                 'volume': {
                   'type': 'string',
@@ -1233,12 +1231,8 @@ export default {
             'description': 'Basic auth password',
             'type': 'string',
           },
-          'port': {
-            'description': 'Port to listen on',
-            'type': 'number',
-          },
           'target_deployment': {
-            'description': 'Target deployment name',
+            'description': 'A deployment the service should point to',
             'type': 'string',
           },
           'target_port': {
@@ -1250,6 +1244,13 @@ export default {
             'description': 'Protocol',
             'type': 'string',
           },
+          'target_servers': {
+            'description': 'The servers the service should load balance between',
+            'items': {
+              'type': 'string',
+            },
+            'type': 'array',
+          },
           'username': {
             'description': 'Basic auth username',
             'type': 'string',
@@ -1257,7 +1258,6 @@ export default {
         },
         'required': [
           'name',
-          'target_deployment',
           'target_port',
         ],
         'type': 'object',

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -47,7 +47,7 @@ export class CommandHelper {
 
   get componentStore(): ComponentStore {
     const config_dir = ArcCtlConfig.getConfigDirectory();
-    return new ComponentStore(path.join(config_dir, 'component-store'), 'registry.architect.io');
+    return new ComponentStore(path.join(config_dir, 'component-store'));
   }
 
   get providerStore(): ProviderStore {

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -33,19 +33,6 @@ async function push_action(options: BuildOptions, tag: string): Promise<void> {
     }
 
     console.log(`Pushed image: ${image}`);
-  }, async (deploymentName: string, volumeName: string, image: string, host_path: string, mount_path: string) => {
-    const [name, version] = tag.split(':');
-    const ref = `${name}/${deploymentName}/volume/${volumeName}:${version}`;
-    await command_helper.componentStore.pushVolume(
-      {
-        component: deploymentName,
-        mount_path,
-        host_path,
-      },
-      image,
-      ref,
-    );
-    console.log(`Pushed Volume ${ref}`);
   });
 
   await command_helper.componentStore.push(tag);

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -47,6 +47,9 @@ async function push_action(options: BuildOptions, tag: string): Promise<void> {
     );
     console.log(`Pushed Volume ${ref}`);
   });
+
+  await command_helper.componentStore.push(tag);
+
   console.log(`Pushed Component: ${tag}`);
 }
 

--- a/src/component-store/store.ts
+++ b/src/component-store/store.ts
@@ -38,9 +38,9 @@ export class ComponentStore {
   private db: ComponentStoreDB;
   private default_registry: string;
 
-  constructor(cache_dir: string, default_registry: string) {
+  constructor(cache_dir: string, default_registry?: string) {
     this.cache_dir = cache_dir;
-    this.default_registry = default_registry;
+    this.default_registry = default_registry || 'registry-1.docker.io';
 
     try {
       this.db = JSON.parse(Deno.readTextFileSync(path.join(this.cache_dir, CACHE_DB_FILENAME)));

--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -34,13 +34,6 @@ export type VolumeTagFn = (
 ) => Promise<string>;
 
 export type DockerPushFn = (image: string) => Promise<void>;
-export type VolumePushFn = (
-  deployment_name: string,
-  volume_name: string,
-  image: string,
-  host_path: string,
-  mount_path: string,
-) => Promise<void>;
 
 export type ComponentDependencies = Array<{
   component: string;
@@ -56,5 +49,5 @@ export abstract class Component {
 
   public abstract tag(tagFn: DockerTagFn, volumeTagFn: VolumeTagFn): Promise<Component>;
 
-  public abstract push(pushFn: DockerPushFn, volumePushFn: VolumePushFn): Promise<Component>;
+  public abstract push(pushFn: DockerPushFn): Promise<Component>;
 }

--- a/src/components/v1/common.ts
+++ b/src/components/v1/common.ts
@@ -36,6 +36,7 @@ export type RuntimeSchemaV1 = DockerSchemaV1 & {
       mount_path: string;
       host_path?: string;
       readonly?: boolean | string;
+      image?: string;
     }
   >;
 };

--- a/src/datacenters/datacenter-schema.ts
+++ b/src/datacenters/datacenter-schema.ts
@@ -353,6 +353,53 @@ export default {
                               'account': {
                                 'type': 'string',
                               },
+                              'databaseCluster': {
+                                'description': 'Unique ID of the database cluster backing this schema',
+                                'type': 'string',
+                              },
+                              'databaseType': {
+                                'description': 'Type of database required by the schema',
+                                'type': 'string',
+                              },
+                              'databaseVersion': {
+                                'description': 'Version of the database type the schema creation process expects',
+                                'type': 'string',
+                              },
+                              'name': {
+                                'description': 'Name to give to the new schema',
+                                'type': 'string',
+                              },
+                              'type': {
+                                'const': 'database',
+                                'type': 'string',
+                              },
+                            },
+                            'required': [
+                              'account',
+                              'databaseCluster',
+                              'databaseType',
+                              'databaseVersion',
+                              'name',
+                              'type',
+                            ],
+                            'type': 'object',
+                          },
+                        },
+                        {
+                          'if': {
+                            'properties': {
+                              'type': {
+                                'const': 'databaseCluster',
+                                'type': 'string',
+                              },
+                            },
+                          },
+                          'then': {
+                            'additionalProperties': false,
+                            'properties': {
+                              'account': {
+                                'type': 'string',
+                              },
                               'databaseSize': {
                                 'description': 'Size of the database instance to create',
                                 'type': 'string',
@@ -378,7 +425,7 @@ export default {
                                 'type': 'string',
                               },
                               'type': {
-                                'const': 'database',
+                                'const': 'databaseCluster',
                                 'type': 'string',
                               },
                               'vpc': {
@@ -395,53 +442,6 @@ export default {
                               'region',
                               'type',
                               'vpc',
-                            ],
-                            'type': 'object',
-                          },
-                        },
-                        {
-                          'if': {
-                            'properties': {
-                              'type': {
-                                'const': 'databaseSchema',
-                                'type': 'string',
-                              },
-                            },
-                          },
-                          'then': {
-                            'additionalProperties': false,
-                            'properties': {
-                              'account': {
-                                'type': 'string',
-                              },
-                              'database': {
-                                'description': 'Unique ID of the database backing this schema',
-                                'type': 'string',
-                              },
-                              'databaseType': {
-                                'description': 'Type of database required by the schema',
-                                'type': 'string',
-                              },
-                              'databaseVersion': {
-                                'description': 'Version of the database type the schema creation process expects',
-                                'type': 'string',
-                              },
-                              'name': {
-                                'description': 'Name to give to the new schema',
-                                'type': 'string',
-                              },
-                              'type': {
-                                'const': 'databaseSchema',
-                                'type': 'string',
-                              },
-                            },
-                            'required': [
-                              'account',
-                              'database',
-                              'databaseType',
-                              'databaseVersion',
-                              'name',
-                              'type',
                             ],
                             'type': 'object',
                           },
@@ -515,8 +515,8 @@ export default {
                               'account': {
                                 'type': 'string',
                               },
-                              'databaseSchema': {
-                                'description': 'The schema the user should have access to',
+                              'database': {
+                                'description': 'The database the user should have access to',
                                 'type': 'string',
                               },
                               'type': {
@@ -530,7 +530,7 @@ export default {
                             },
                             'required': [
                               'account',
-                              'databaseSchema',
+                              'database',
                               'type',
                               'username',
                             ],
@@ -672,7 +672,6 @@ export default {
                                     },
                                   },
                                   'required': [
-                                    'port',
                                     'target_port',
                                   ],
                                   'type': 'object',
@@ -870,10 +869,15 @@ export default {
                                       'description': 'Unique ID of the service the deployment should attach itself to',
                                       'type': 'string',
                                     },
+                                    'port': {
+                                      'description': 'The port the service deployment is listening on',
+                                      'type': 'string',
+                                    },
                                   },
                                   'required': [
                                     'id',
                                     'account',
+                                    'port',
                                   ],
                                   'type': 'object',
                                 },
@@ -1099,7 +1103,7 @@ export default {
                                       'items': {
                                         'additionalProperties': false,
                                         'properties': {
-                                          'local_image': {
+                                          'image': {
                                             'type': 'string',
                                           },
                                           'mount_path': {
@@ -1107,9 +1111,6 @@ export default {
                                           },
                                           'readonly': {
                                             'type': 'boolean',
-                                          },
-                                          'remote_image': {
-                                            'type': 'string',
                                           },
                                           'volume': {
                                             'type': 'string',
@@ -1142,7 +1143,7 @@ export default {
                                 'items': {
                                   'additionalProperties': false,
                                   'properties': {
-                                    'local_image': {
+                                    'image': {
                                       'type': 'string',
                                     },
                                     'mount_path': {
@@ -1150,9 +1151,6 @@ export default {
                                     },
                                     'readonly': {
                                       'type': 'boolean',
-                                    },
-                                    'remote_image': {
-                                      'type': 'string',
                                     },
                                     'volume': {
                                       'type': 'string',
@@ -1792,12 +1790,8 @@ export default {
                                 'description': 'Basic auth password',
                                 'type': 'string',
                               },
-                              'port': {
-                                'description': 'Port to listen on',
-                                'type': 'number',
-                              },
                               'target_deployment': {
-                                'description': 'Target deployment name',
+                                'description': 'A deployment the service should point to',
                                 'type': 'string',
                               },
                               'target_port': {
@@ -1808,6 +1802,13 @@ export default {
                                 'default': 'http',
                                 'description': 'Protocol',
                                 'type': 'string',
+                              },
+                              'target_servers': {
+                                'description': 'The servers the service should load balance between',
+                                'items': {
+                                  'type': 'string',
+                                },
+                                'type': 'array',
                               },
                               'type': {
                                 'const': 'service',
@@ -1821,7 +1822,6 @@ export default {
                             'required': [
                               'account',
                               'name',
-                              'target_deployment',
                               'target_port',
                               'type',
                             ],
@@ -2087,7 +2087,7 @@ export default {
                             'arcctlAccount',
                             'cronjob',
                             'database',
-                            'databaseSchema',
+                            'databaseCluster',
                             'databaseUser',
                             'databaseVersion',
                             'deployment',
@@ -2232,19 +2232,19 @@ export default {
                             'type': 'object',
                           },
                           {
-                            'description': 'Unique ID of the database backing this schema',
+                            'description': 'The database the user should have access to',
                             'type': 'string',
                           },
                         ],
                       },
-                      'databaseSchema': {
+                      'databaseCluster': {
                         'anyOf': [
                           {
                             'additionalProperties': false,
                             'type': 'object',
                           },
                           {
-                            'description': 'The schema the user should have access to',
+                            'description': 'Unique ID of the database cluster backing this schema',
                             'type': 'string',
                           },
                         ],
@@ -2268,11 +2268,11 @@ export default {
                             'type': 'object',
                           },
                           {
-                            'description': 'The type of database engine to use',
+                            'description': 'Type of database required by the schema',
                             'type': 'string',
                           },
                           {
-                            'description': 'Type of database required by the schema',
+                            'description': 'The type of database engine to use',
                             'type': 'string',
                           },
                           {
@@ -2287,11 +2287,11 @@ export default {
                             'type': 'object',
                           },
                           {
-                            'description': 'Refers to the unique ID of a `databaseVersion` response',
+                            'description': 'Version of the database type the schema creation process expects',
                             'type': 'string',
                           },
                           {
-                            'description': 'Version of the database type the schema creation process expects',
+                            'description': 'Refers to the unique ID of a `databaseVersion` response',
                             'type': 'string',
                           },
                         ],
@@ -2480,11 +2480,11 @@ export default {
                             'type': 'string',
                           },
                           {
-                            'description': 'Unique name for the database',
+                            'description': 'Name to give to the new schema',
                             'type': 'string',
                           },
                           {
-                            'description': 'Name to give to the new schema',
+                            'description': 'Unique name for the database',
                             'type': 'string',
                           },
                           {
@@ -2612,10 +2612,6 @@ export default {
                               'string',
                               'number',
                             ],
-                          },
-                          {
-                            'description': 'Port to listen on',
-                            'type': 'number',
                           },
                         ],
                       },
@@ -2890,7 +2886,7 @@ export default {
                             'type': 'object',
                           },
                           {
-                            'description': 'Target deployment name',
+                            'description': 'A deployment the service should point to',
                             'type': 'string',
                           },
                         ],
@@ -2920,6 +2916,10 @@ export default {
                           },
                         ],
                       },
+                      'target_servers': {
+                        'additionalProperties': false,
+                        'type': 'object',
+                      },
                       'ttl': {
                         'anyOf': [
                           {
@@ -2936,7 +2936,7 @@ export default {
                           'arcctlAccount',
                           'cronjob',
                           'database',
-                          'databaseSchema',
+                          'databaseCluster',
                           'databaseSize',
                           'databaseType',
                           'databaseUser',
@@ -3285,6 +3285,53 @@ export default {
                         'account': {
                           'type': 'string',
                         },
+                        'databaseCluster': {
+                          'description': 'Unique ID of the database cluster backing this schema',
+                          'type': 'string',
+                        },
+                        'databaseType': {
+                          'description': 'Type of database required by the schema',
+                          'type': 'string',
+                        },
+                        'databaseVersion': {
+                          'description': 'Version of the database type the schema creation process expects',
+                          'type': 'string',
+                        },
+                        'name': {
+                          'description': 'Name to give to the new schema',
+                          'type': 'string',
+                        },
+                        'type': {
+                          'const': 'database',
+                          'type': 'string',
+                        },
+                      },
+                      'required': [
+                        'account',
+                        'databaseCluster',
+                        'databaseType',
+                        'databaseVersion',
+                        'name',
+                        'type',
+                      ],
+                      'type': 'object',
+                    },
+                  },
+                  {
+                    'if': {
+                      'properties': {
+                        'type': {
+                          'const': 'databaseCluster',
+                          'type': 'string',
+                        },
+                      },
+                    },
+                    'then': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'account': {
+                          'type': 'string',
+                        },
                         'databaseSize': {
                           'description': 'Size of the database instance to create',
                           'type': 'string',
@@ -3310,7 +3357,7 @@ export default {
                           'type': 'string',
                         },
                         'type': {
-                          'const': 'database',
+                          'const': 'databaseCluster',
                           'type': 'string',
                         },
                         'vpc': {
@@ -3327,53 +3374,6 @@ export default {
                         'region',
                         'type',
                         'vpc',
-                      ],
-                      'type': 'object',
-                    },
-                  },
-                  {
-                    'if': {
-                      'properties': {
-                        'type': {
-                          'const': 'databaseSchema',
-                          'type': 'string',
-                        },
-                      },
-                    },
-                    'then': {
-                      'additionalProperties': false,
-                      'properties': {
-                        'account': {
-                          'type': 'string',
-                        },
-                        'database': {
-                          'description': 'Unique ID of the database backing this schema',
-                          'type': 'string',
-                        },
-                        'databaseType': {
-                          'description': 'Type of database required by the schema',
-                          'type': 'string',
-                        },
-                        'databaseVersion': {
-                          'description': 'Version of the database type the schema creation process expects',
-                          'type': 'string',
-                        },
-                        'name': {
-                          'description': 'Name to give to the new schema',
-                          'type': 'string',
-                        },
-                        'type': {
-                          'const': 'databaseSchema',
-                          'type': 'string',
-                        },
-                      },
-                      'required': [
-                        'account',
-                        'database',
-                        'databaseType',
-                        'databaseVersion',
-                        'name',
-                        'type',
                       ],
                       'type': 'object',
                     },
@@ -3447,8 +3447,8 @@ export default {
                         'account': {
                           'type': 'string',
                         },
-                        'databaseSchema': {
-                          'description': 'The schema the user should have access to',
+                        'database': {
+                          'description': 'The database the user should have access to',
                           'type': 'string',
                         },
                         'type': {
@@ -3462,7 +3462,7 @@ export default {
                       },
                       'required': [
                         'account',
-                        'databaseSchema',
+                        'database',
                         'type',
                         'username',
                       ],
@@ -3604,7 +3604,6 @@ export default {
                               },
                             },
                             'required': [
-                              'port',
                               'target_port',
                             ],
                             'type': 'object',
@@ -3801,10 +3800,15 @@ export default {
                                 'description': 'Unique ID of the service the deployment should attach itself to',
                                 'type': 'string',
                               },
+                              'port': {
+                                'description': 'The port the service deployment is listening on',
+                                'type': 'string',
+                              },
                             },
                             'required': [
                               'id',
                               'account',
+                              'port',
                             ],
                             'type': 'object',
                           },
@@ -4029,7 +4033,7 @@ export default {
                                 'items': {
                                   'additionalProperties': false,
                                   'properties': {
-                                    'local_image': {
+                                    'image': {
                                       'type': 'string',
                                     },
                                     'mount_path': {
@@ -4037,9 +4041,6 @@ export default {
                                     },
                                     'readonly': {
                                       'type': 'boolean',
-                                    },
-                                    'remote_image': {
-                                      'type': 'string',
                                     },
                                     'volume': {
                                       'type': 'string',
@@ -4072,7 +4073,7 @@ export default {
                           'items': {
                             'additionalProperties': false,
                             'properties': {
-                              'local_image': {
+                              'image': {
                                 'type': 'string',
                               },
                               'mount_path': {
@@ -4080,9 +4081,6 @@ export default {
                               },
                               'readonly': {
                                 'type': 'boolean',
-                              },
-                              'remote_image': {
-                                'type': 'string',
                               },
                               'volume': {
                                 'type': 'string',
@@ -4721,12 +4719,8 @@ export default {
                           'description': 'Basic auth password',
                           'type': 'string',
                         },
-                        'port': {
-                          'description': 'Port to listen on',
-                          'type': 'number',
-                        },
                         'target_deployment': {
-                          'description': 'Target deployment name',
+                          'description': 'A deployment the service should point to',
                           'type': 'string',
                         },
                         'target_port': {
@@ -4737,6 +4731,13 @@ export default {
                           'default': 'http',
                           'description': 'Protocol',
                           'type': 'string',
+                        },
+                        'target_servers': {
+                          'description': 'The servers the service should load balance between',
+                          'items': {
+                            'type': 'string',
+                          },
+                          'type': 'array',
                         },
                         'type': {
                           'const': 'service',
@@ -4750,7 +4751,6 @@ export default {
                       'required': [
                         'account',
                         'name',
-                        'target_deployment',
                         'target_port',
                         'type',
                       ],
@@ -5016,7 +5016,7 @@ export default {
                       'arcctlAccount',
                       'cronjob',
                       'database',
-                      'databaseSchema',
+                      'databaseCluster',
                       'databaseUser',
                       'databaseVersion',
                       'deployment',
@@ -5307,6 +5307,53 @@ export default {
                     'account': {
                       'type': 'string',
                     },
+                    'databaseCluster': {
+                      'description': 'Unique ID of the database cluster backing this schema',
+                      'type': 'string',
+                    },
+                    'databaseType': {
+                      'description': 'Type of database required by the schema',
+                      'type': 'string',
+                    },
+                    'databaseVersion': {
+                      'description': 'Version of the database type the schema creation process expects',
+                      'type': 'string',
+                    },
+                    'name': {
+                      'description': 'Name to give to the new schema',
+                      'type': 'string',
+                    },
+                    'type': {
+                      'const': 'database',
+                      'type': 'string',
+                    },
+                  },
+                  'required': [
+                    'account',
+                    'databaseCluster',
+                    'databaseType',
+                    'databaseVersion',
+                    'name',
+                    'type',
+                  ],
+                  'type': 'object',
+                },
+              },
+              {
+                'if': {
+                  'properties': {
+                    'type': {
+                      'const': 'databaseCluster',
+                      'type': 'string',
+                    },
+                  },
+                },
+                'then': {
+                  'additionalProperties': false,
+                  'properties': {
+                    'account': {
+                      'type': 'string',
+                    },
                     'databaseSize': {
                       'description': 'Size of the database instance to create',
                       'type': 'string',
@@ -5332,7 +5379,7 @@ export default {
                       'type': 'string',
                     },
                     'type': {
-                      'const': 'database',
+                      'const': 'databaseCluster',
                       'type': 'string',
                     },
                     'vpc': {
@@ -5349,53 +5396,6 @@ export default {
                     'region',
                     'type',
                     'vpc',
-                  ],
-                  'type': 'object',
-                },
-              },
-              {
-                'if': {
-                  'properties': {
-                    'type': {
-                      'const': 'databaseSchema',
-                      'type': 'string',
-                    },
-                  },
-                },
-                'then': {
-                  'additionalProperties': false,
-                  'properties': {
-                    'account': {
-                      'type': 'string',
-                    },
-                    'database': {
-                      'description': 'Unique ID of the database backing this schema',
-                      'type': 'string',
-                    },
-                    'databaseType': {
-                      'description': 'Type of database required by the schema',
-                      'type': 'string',
-                    },
-                    'databaseVersion': {
-                      'description': 'Version of the database type the schema creation process expects',
-                      'type': 'string',
-                    },
-                    'name': {
-                      'description': 'Name to give to the new schema',
-                      'type': 'string',
-                    },
-                    'type': {
-                      'const': 'databaseSchema',
-                      'type': 'string',
-                    },
-                  },
-                  'required': [
-                    'account',
-                    'database',
-                    'databaseType',
-                    'databaseVersion',
-                    'name',
-                    'type',
                   ],
                   'type': 'object',
                 },
@@ -5469,8 +5469,8 @@ export default {
                     'account': {
                       'type': 'string',
                     },
-                    'databaseSchema': {
-                      'description': 'The schema the user should have access to',
+                    'database': {
+                      'description': 'The database the user should have access to',
                       'type': 'string',
                     },
                     'type': {
@@ -5484,7 +5484,7 @@ export default {
                   },
                   'required': [
                     'account',
-                    'databaseSchema',
+                    'database',
                     'type',
                     'username',
                   ],
@@ -5626,7 +5626,6 @@ export default {
                           },
                         },
                         'required': [
-                          'port',
                           'target_port',
                         ],
                         'type': 'object',
@@ -5822,10 +5821,15 @@ export default {
                             'description': 'Unique ID of the service the deployment should attach itself to',
                             'type': 'string',
                           },
+                          'port': {
+                            'description': 'The port the service deployment is listening on',
+                            'type': 'string',
+                          },
                         },
                         'required': [
                           'id',
                           'account',
+                          'port',
                         ],
                         'type': 'object',
                       },
@@ -6050,7 +6054,7 @@ export default {
                             'items': {
                               'additionalProperties': false,
                               'properties': {
-                                'local_image': {
+                                'image': {
                                   'type': 'string',
                                 },
                                 'mount_path': {
@@ -6058,9 +6062,6 @@ export default {
                                 },
                                 'readonly': {
                                   'type': 'boolean',
-                                },
-                                'remote_image': {
-                                  'type': 'string',
                                 },
                                 'volume': {
                                   'type': 'string',
@@ -6093,7 +6094,7 @@ export default {
                       'items': {
                         'additionalProperties': false,
                         'properties': {
-                          'local_image': {
+                          'image': {
                             'type': 'string',
                           },
                           'mount_path': {
@@ -6101,9 +6102,6 @@ export default {
                           },
                           'readonly': {
                             'type': 'boolean',
-                          },
-                          'remote_image': {
-                            'type': 'string',
                           },
                           'volume': {
                             'type': 'string',
@@ -6742,12 +6740,8 @@ export default {
                       'description': 'Basic auth password',
                       'type': 'string',
                     },
-                    'port': {
-                      'description': 'Port to listen on',
-                      'type': 'number',
-                    },
                     'target_deployment': {
-                      'description': 'Target deployment name',
+                      'description': 'A deployment the service should point to',
                       'type': 'string',
                     },
                     'target_port': {
@@ -6758,6 +6752,13 @@ export default {
                       'default': 'http',
                       'description': 'Protocol',
                       'type': 'string',
+                    },
+                    'target_servers': {
+                      'description': 'The servers the service should load balance between',
+                      'items': {
+                        'type': 'string',
+                      },
+                      'type': 'array',
                     },
                     'type': {
                       'const': 'service',
@@ -6771,7 +6772,6 @@ export default {
                   'required': [
                     'account',
                     'name',
-                    'target_deployment',
                     'target_port',
                     'type',
                   ],
@@ -7037,7 +7037,7 @@ export default {
                   'arcctlAccount',
                   'cronjob',
                   'database',
-                  'databaseSchema',
+                  'databaseCluster',
                   'databaseUser',
                   'databaseVersion',
                   'deployment',
@@ -7095,7 +7095,7 @@ export default {
               'database': {
                 'type': 'string',
               },
-              'databaseSchema': {
+              'databaseCluster': {
                 'type': 'string',
               },
               'databaseSize': {
@@ -7166,7 +7166,7 @@ export default {
                   'arcctlAccount',
                   'cronjob',
                   'database',
-                  'databaseSchema',
+                  'databaseCluster',
                   'databaseSize',
                   'databaseType',
                   'databaseUser',

--- a/src/datacenters/datacenter.schema.json
+++ b/src/datacenters/datacenter.schema.json
@@ -1087,7 +1087,7 @@
                                       "items": {
                                         "additionalProperties": false,
                                         "properties": {
-                                          "local_image": {
+                                          "image": {
                                             "type": "string"
                                           },
                                           "mount_path": {
@@ -1095,9 +1095,6 @@
                                           },
                                           "readonly": {
                                             "type": "boolean"
-                                          },
-                                          "remote_image": {
-                                            "type": "string"
                                           },
                                           "volume": {
                                             "type": "string"
@@ -1130,7 +1127,7 @@
                                 "items": {
                                   "additionalProperties": false,
                                   "properties": {
-                                    "local_image": {
+                                    "image": {
                                       "type": "string"
                                     },
                                     "mount_path": {
@@ -1138,9 +1135,6 @@
                                     },
                                     "readonly": {
                                       "type": "boolean"
-                                    },
-                                    "remote_image": {
-                                      "type": "string"
                                     },
                                     "volume": {
                                       "type": "string"
@@ -4003,7 +3997,7 @@
                                 "items": {
                                   "additionalProperties": false,
                                   "properties": {
-                                    "local_image": {
+                                    "image": {
                                       "type": "string"
                                     },
                                     "mount_path": {
@@ -4011,9 +4005,6 @@
                                     },
                                     "readonly": {
                                       "type": "boolean"
-                                    },
-                                    "remote_image": {
-                                      "type": "string"
                                     },
                                     "volume": {
                                       "type": "string"
@@ -4046,7 +4037,7 @@
                           "items": {
                             "additionalProperties": false,
                             "properties": {
-                              "local_image": {
+                              "image": {
                                 "type": "string"
                               },
                               "mount_path": {
@@ -4054,9 +4045,6 @@
                               },
                               "readonly": {
                                 "type": "boolean"
-                              },
-                              "remote_image": {
-                                "type": "string"
                               },
                               "volume": {
                                 "type": "string"
@@ -6015,7 +6003,7 @@
                             "items": {
                               "additionalProperties": false,
                               "properties": {
-                                "local_image": {
+                                "image": {
                                   "type": "string"
                                 },
                                 "mount_path": {
@@ -6023,9 +6011,6 @@
                                 },
                                 "readonly": {
                                   "type": "boolean"
-                                },
-                                "remote_image": {
-                                  "type": "string"
                                 },
                                 "volume": {
                                   "type": "string"
@@ -6058,7 +6043,7 @@
                       "items": {
                         "additionalProperties": false,
                         "properties": {
-                          "local_image": {
+                          "image": {
                             "type": "string"
                           },
                           "mount_path": {
@@ -6066,9 +6051,6 @@
                           },
                           "readonly": {
                             "type": "boolean"
-                          },
-                          "remote_image": {
-                            "type": "string"
                           },
                           "volume": {
                             "type": "string"

--- a/src/oci/config/config.ts
+++ b/src/oci/config/config.ts
@@ -1,0 +1,114 @@
+import * as path from 'std/path/mod.ts';
+import { ConfigFile } from './configfile/file.ts';
+import { NativeCredentialsClient } from './credentials/native-client.ts';
+
+const CONFIG_FILE_NAME = 'config.json';
+const CONFIG_FILE_DIR = '.docker';
+const OLD_CONFIG_FILE = '.dockercfg';
+const CONTEXTS_DIR = 'contexts';
+
+export class Config {
+  private static initConfigDir?: boolean;
+  private static configDir?: string;
+  private static homeDir?: string;
+
+  private static resetHomeDir(): void {
+    this.homeDir = undefined;
+  }
+
+  private static getHomeDir(): string {
+    if (!this.homeDir) {
+      this.homeDir = Deno.env.get('HOME') || '';
+    }
+
+    return this.homeDir;
+  }
+
+  private static resetConfigDir(): void {
+    this.configDir = undefined;
+    this.initConfigDir = false;
+  }
+
+  private static setConfigDir(): void {
+    if (this.configDir) {
+      return;
+    }
+
+    this.configDir = Deno.env.get('DOCKER_CONFIG') || '';
+    if (!this.configDir) {
+      this.configDir = path.join(this.getHomeDir(), CONFIG_FILE_DIR);
+    }
+  }
+
+  public static dir(): string {
+    if (!this.initConfigDir) {
+      this.setConfigDir();
+      this.initConfigDir = true;
+    }
+
+    return this.configDir || '';
+  }
+
+  public static contextStoreDir(): string {
+    return path.join(this.dir(), CONTEXTS_DIR);
+  }
+
+  public static setDir(dir: string): void {
+    this.configDir = dir;
+  }
+
+  public static path(...p: string[]): string {
+    const full = path.join(this.dir(), ...p);
+    if (!(full.startsWith(this.dir() + path.SEP))) {
+      throw new Error(`path ${full} is outside of the root config directory ${this.dir()}`);
+    }
+
+    return full;
+  }
+
+  public static load(inputDir?: string): ConfigFile {
+    const configDir = inputDir || this.dir();
+    const filename = path.join(configDir, CONFIG_FILE_NAME);
+    return new ConfigFile(filename);
+  }
+
+  public static async loadDefaultConfigFile(): Promise<ConfigFile> {
+    const file = this.load();
+    if (!file.containsAuth()) {
+      switch (Deno.build.os) {
+        case 'darwin': {
+          const store = await new Promise<string>((resolve) => {
+            const client = new NativeCredentialsClient('osxkeychain');
+            client.version().then(() => resolve('osxkeychain')).catch(() => resolve(''));
+          });
+
+          file.credsStore = store;
+          break;
+        }
+        case 'linux': {
+          const store = await new Promise<string>((resolve) => {
+            const passClient = new NativeCredentialsClient('pass');
+            const secretServiceClient = new NativeCredentialsClient('secretservice');
+            passClient.version().then(() => resolve('pass')).catch(() => {
+              secretServiceClient.version().then(() => resolve('secretservice')).catch(() => resolve(''));
+            });
+          });
+
+          file.credsStore = store;
+          break;
+        }
+        case 'windows': {
+          const store = await new Promise<string>((resolve) => {
+            const client = new NativeCredentialsClient('wincred');
+            client.version().then(() => resolve('wincred')).catch(() => resolve(''));
+          });
+
+          file.credsStore = store;
+          break;
+        }
+      }
+    }
+
+    return file;
+  }
+}

--- a/src/oci/config/configfile/file.ts
+++ b/src/oci/config/configfile/file.ts
@@ -1,0 +1,197 @@
+import { AuthsFile } from '../credentials/auths-file.ts';
+import { FileStore } from '../credentials/file-store.ts';
+import { NativeStore } from '../credentials/native-store.ts';
+import { Store } from '../credentials/store.ts';
+import { AuthConfig, decodeAuth, encodeAuth } from '../types/auth.ts';
+
+type ProxyConfig = {
+  httpProxy?: string;
+  httpsProxy?: string;
+  noProxy?: string;
+  ftpProxy?: string;
+  allProxy?: string;
+};
+
+export class ConfigFile implements AuthsFile {
+  filename: string;
+  auths: Record<string, AuthConfig>;
+  HttpHeaders?: Record<string, string>;
+  psFormat?: string;
+  imagesFormat?: string;
+  networksFormat?: string;
+  pluginsFormat?: string;
+  volumesFormat?: string;
+  statsFormat?: string;
+  detachKeys?: string;
+  credsStore?: string;
+  credHelpers?: Record<string, string>;
+  serviceInspectFormat?: string;
+  servicesFormat?: string;
+  tasksFormat?: string;
+  secretFormat?: string;
+  configFormat?: string;
+  nodesFormat?: string;
+  pruneFilters?: string[];
+  proxies?: Record<string, ProxyConfig>;
+  experimental?: string;
+  currentContext?: string;
+  cliPluginsExtraDirs?: string[];
+  plugins?: Record<string, Record<string, string>>;
+  aliases?: Record<string, string>;
+
+  constructor(filename: string) {
+    this.filename = filename;
+    this.auths = {};
+    try {
+      const strContents = Deno.readTextFileSync(filename);
+      this.load(JSON.parse(strContents));
+    } catch {
+      // Intentionally left blank
+    }
+  }
+
+  load(configData: Record<string, unknown>) {
+    Object.assign(this, configData);
+
+    for (const [addr, ac] of Object.entries(this.auths)) {
+      if (ac.auth) {
+        const { username, password } = decodeAuth(ac.auth);
+        ac.username = username;
+        ac.password = password;
+      }
+
+      delete ac.auth;
+      ac.serveraddress = addr;
+      this.auths[addr] = ac;
+    }
+  }
+
+  containsAuth(): boolean {
+    return Boolean(this.credsStore) ||
+      Object.keys(this.credHelpers || {}).length > 0 ||
+      Object.keys(this.auths).length > 0;
+  }
+
+  getAuthConfigs(): Record<string, AuthConfig> {
+    return this.auths;
+  }
+
+  save(): void {
+    if (!this.filename) {
+      throw new Error(`Can't save config with empty filename`);
+    }
+
+    // Encode sensitive data into new struct
+    const tmpAuthConfigs = { ...this.auths };
+    for (const [key, authConfig] of Object.entries(this.auths)) {
+      const authCopy = { ...authConfig };
+      authCopy.auth = encodeAuth(authCopy);
+      delete authCopy.username;
+      delete authCopy.password;
+      delete authCopy.serveraddress;
+      tmpAuthConfigs[key] = authCopy;
+    }
+
+    // User-Agent header is automatically set, and should not be stored in the configuration
+    for (const key of Object.keys(this.HttpHeaders || {})) {
+      if (key.toLowerCase() === 'user-agent') {
+        delete this.HttpHeaders![key];
+      }
+    }
+
+    Deno.writeTextFileSync(
+      this.filename,
+      JSON.stringify(
+        {
+          ...this,
+          auths: tmpAuthConfigs,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  // References:
+  //   - https://github.com/docker/cli/blob/v24.0.0-beta.2/cli/config/configfile/file.go#L179
+  parseProxyConfig(host: string, runOpts: Record<string, string> = {}): Record<string, string> {
+    const cfgKey = this.proxies?.[host] ? host : 'default';
+    const config = this.proxies?.[cfgKey] || {};
+    const permitted: Record<string, string | undefined> = {
+      'HTTP_PROXY': config.httpProxy,
+      'HTTPS_PROXY': config.httpsProxy,
+      'NO_PROXY': config.noProxy,
+      'FTP_PROXY': config.ftpProxy,
+      'ALL_PROXY': config.allProxy,
+    };
+
+    for (const key in permitted) {
+      if (!permitted[key]) {
+        continue;
+      } else if (runOpts[key]) {
+        runOpts[key] = permitted[key]!;
+      } else if (runOpts[key.toLowerCase()]) {
+        runOpts[key.toLowerCase()] = permitted[key]!;
+      }
+    }
+
+    return runOpts;
+  }
+
+  getCredentialsStore(registryHostname?: string): Store {
+    let credsStore = this.credsStore || '';
+    credsStore = registryHostname ? this.credHelpers?.[registryHostname] || credsStore : credsStore;
+    if (credsStore) {
+      return new NativeStore(this, credsStore);
+    }
+
+    return new FileStore(this);
+  }
+
+  async getAuthConfig(serverAddress: string): Promise<AuthConfig | undefined> {
+    if (serverAddress.includes('registry-1.docker.io')) {
+      return this.getCredentialsStore(`https://index.docker.io/v1/`).get('https://index.docker.io/v1/');
+    }
+
+    return this.getCredentialsStore(serverAddress).get(serverAddress);
+  }
+
+  async getAllCredentials(): Promise<Record<string, AuthConfig>> {
+    const auths: Record<string, AuthConfig> = {};
+    const defaultStore = this.getCredentialsStore('');
+    const newAuths = await defaultStore.getAll();
+
+    for (const [key, value] of Object.entries(newAuths)) {
+      auths[key] = value;
+    }
+
+    // Auth configs from a registry-specific helper should override those from the default store.
+    for (const registryHostname in this.credHelpers || {}) {
+      const authConfig = await this.getAuthConfig(registryHostname);
+      if (authConfig) {
+        auths[registryHostname] = authConfig;
+      }
+    }
+
+    return auths;
+  }
+
+  pluginConfig(pluginName: string, option: string): string {
+    return this.plugins?.[pluginName]?.[option] || '';
+  }
+
+  setPluginConfig(pluginName: string, option: string, value?: string): void {
+    this.plugins = this.plugins || {};
+    this.plugins[pluginName] = this.plugins[pluginName] || {};
+
+    if (!value) {
+      delete this.plugins[pluginName][option];
+    } else {
+      this.plugins[pluginName][option] = value;
+    }
+
+    if (Object.keys(this.plugins[pluginName]).length === 0) {
+      delete this.plugins[pluginName];
+    }
+  }
+}

--- a/src/oci/config/credentials/auths-file.ts
+++ b/src/oci/config/credentials/auths-file.ts
@@ -1,0 +1,7 @@
+import { AuthConfig } from '../types/auth.ts';
+
+export interface AuthsFile {
+  filename: string;
+  auths: Record<string, AuthConfig>;
+  save(): void;
+}

--- a/src/oci/config/credentials/file-store.ts
+++ b/src/oci/config/credentials/file-store.ts
@@ -1,0 +1,57 @@
+import { AuthConfig } from '../types/auth.ts';
+import { AuthsFile } from './auths-file.ts';
+import { Store } from './store.ts';
+
+export class FileStore implements Store {
+  private file: AuthsFile;
+
+  constructor(file: AuthsFile) {
+    this.file = file;
+  }
+
+  private convertToHostname(url: string): string {
+    if (url.includes('://')) {
+      const { hostname } = new URL(url);
+      return hostname;
+    }
+
+    return url;
+  }
+
+  isFileStore(): boolean {
+    return true;
+  }
+
+  erase(serverAddress: string): Promise<void> {
+    delete this.file.auths[serverAddress];
+    this.file.save();
+    return Promise.resolve();
+  }
+
+  get(serverAddress: string): Promise<AuthConfig | undefined> {
+    const authConfig = this.file.auths[serverAddress];
+    if (authConfig) return Promise.resolve(authConfig);
+
+    for (const [key, value] of Object.entries(this.file.auths)) {
+      if (serverAddress === this.convertToHostname(key)) {
+        return Promise.resolve(value);
+      }
+    }
+
+    return Promise.resolve(undefined);
+  }
+
+  getAll(): Promise<Record<string, AuthConfig>> {
+    return Promise.resolve(this.file.auths);
+  }
+
+  store(authConfig: AuthConfig): Promise<void> {
+    if (!authConfig.serveraddress) {
+      throw new Error('Configs must specify a serveraddress');
+    }
+
+    this.file.auths[authConfig.serveraddress] = authConfig;
+    this.file.save();
+    return Promise.resolve();
+  }
+}

--- a/src/oci/config/credentials/native-client.ts
+++ b/src/oci/config/credentials/native-client.ts
@@ -1,0 +1,111 @@
+import { Buffer } from 'std/io/buffer.ts';
+
+enum NativeCredentialsCommand {
+  Erase = 'erase',
+  Get = 'get',
+  List = 'list',
+  Store = 'store',
+  Version = 'version',
+}
+
+export type NativeCredentials = {
+  ServerURL: string;
+  Username: string;
+  Secret: string;
+};
+
+export class NativeCredentialsClient {
+  private programFunc: string;
+
+  constructor(helperSuffix: string) {
+    this.programFunc = `docker-credential-${helperSuffix}`;
+  }
+
+  private async exec(command: NativeCredentialsCommand, stdin?: string): Promise<{
+    code: number;
+    stdout: string;
+    stderr: string;
+  }> {
+    const cmd = new Deno.Command(this.programFunc, {
+      args: [command],
+      stdout: 'piped',
+      stdin: 'piped',
+      stderr: 'piped',
+    });
+
+    const stdout = new Buffer();
+    const stderr = new Buffer();
+
+    const child = cmd.spawn();
+
+    child.stdout.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          stdout.writeSync(chunk);
+        },
+      }),
+    );
+
+    child.stderr.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          stderr.writeSync(chunk);
+        },
+      }),
+    );
+
+    const writer = child.stdin.getWriter();
+    if (stdin) {
+      await writer.write(new TextEncoder().encode(stdin));
+    }
+    await writer.close();
+
+    const status = await child.status;
+    if (status.code !== 0) {
+      throw new Error(
+        new TextDecoder().decode(stderr.bytes()) || `Error running ${this.programFunc} ${command}`,
+      );
+    }
+
+    return {
+      code: status.code,
+      stdout: new TextDecoder().decode(stdout.bytes()),
+      stderr: new TextDecoder().decode(stderr.bytes()),
+    };
+  }
+
+  public async version(): Promise<string> {
+    const { code, stdout } = await this.exec(NativeCredentialsCommand.Version);
+    if (code !== 0) {
+      throw new Error(`Error running ${this.programFunc} ${NativeCredentialsCommand.Version}`);
+    }
+
+    const match = stdout.match(/(v[0-9]\.[0-9]\.[0-9])/);
+    if (!match) {
+      return 'unknown';
+    }
+
+    return match[1];
+  }
+
+  public async erase(serverAddress: string): Promise<void> {
+    await this.exec(NativeCredentialsCommand.Erase, serverAddress);
+  }
+
+  public async get(serverAddress: string): Promise<NativeCredentials> {
+    const { stdout } = await this.exec(NativeCredentialsCommand.Get, serverAddress);
+    return JSON.parse(stdout);
+  }
+
+  public async list(): Promise<Record<string, string>> {
+    const { stdout } = await this.exec(NativeCredentialsCommand.List);
+    return JSON.parse(stdout);
+  }
+
+  public async store(credential: NativeCredentials): Promise<void> {
+    await this.exec(
+      NativeCredentialsCommand.Store,
+      JSON.stringify(credential),
+    );
+  }
+}

--- a/src/oci/config/credentials/native-store.ts
+++ b/src/oci/config/credentials/native-store.ts
@@ -1,0 +1,107 @@
+import { AuthConfig } from '../types/auth.ts';
+import { AuthsFile } from './auths-file.ts';
+import { FileStore } from './file-store.ts';
+import { NativeCredentialsClient } from './native-client.ts';
+import { Store } from './store.ts';
+
+// https://github.com/docker/cli/blob/v24.0.4/cli/config/credentials/native_store.go#L9
+const TOKEN_USERNAME = '<token>';
+
+export class NativeStore implements Store {
+  private client: NativeCredentialsClient;
+  private fileStore: Store;
+
+  constructor(file: AuthsFile, helperSuffix: string) {
+    this.client = new NativeCredentialsClient(helperSuffix);
+    this.fileStore = new FileStore(file);
+  }
+
+  private async getCredentialsFromStore(serverAddress: string): Promise<AuthConfig> {
+    const creds = await this.client.get(serverAddress);
+
+    const res: AuthConfig = {};
+    if (creds.Username === TOKEN_USERNAME) {
+      res.identitytoken = creds.Secret;
+    } else {
+      res.password = creds.Secret;
+      res.username = creds.Username;
+    }
+
+    res.serveraddress = serverAddress;
+    return res;
+  }
+
+  private storeCredentialsInStore(authConfig: AuthConfig): Promise<void> {
+    if (!authConfig.serveraddress) {
+      throw new Error(`Cannot store AuthConfig w/out a server address`);
+    }
+
+    const creds = {
+      ServerURL: authConfig.serveraddress,
+      Username: authConfig.username || '',
+      Secret: authConfig.password || '',
+    };
+
+    if (authConfig.identitytoken) {
+      creds.Username = TOKEN_USERNAME;
+      creds.Secret = authConfig.identitytoken;
+    }
+
+    return this.client.store(creds);
+  }
+
+  async erase(serverAddress: string): Promise<void> {
+    try {
+      return this.client.erase(serverAddress);
+    } catch {
+      return this.fileStore.erase(serverAddress);
+    }
+  }
+
+  async get(serverAddress: string): Promise<AuthConfig | undefined> {
+    const auth = (await this.fileStore.get(serverAddress)) || {};
+
+    try {
+      const creds = await this.getCredentialsFromStore(serverAddress);
+      auth.username = creds.username;
+      auth.identitytoken = creds.identitytoken;
+      auth.password = creds.password;
+    } catch {
+      // Intentionally left blank
+    }
+
+    return Object.keys(auth).length > 0 ? auth : undefined;
+  }
+
+  async getAll(): Promise<Record<string, AuthConfig>> {
+    const auths = await this.client.list();
+    const fileConfigs = await this.fileStore.getAll();
+
+    const res: Record<string, AuthConfig> = {};
+    for (const [key, value] of Object.entries(auths)) {
+      const creds = await this.getCredentialsFromStore(key);
+      res[key] = {
+        ...fileConfigs[key],
+        username: creds.username,
+        password: creds.password,
+        identitytoken: creds.identitytoken,
+      };
+    }
+
+    return res;
+  }
+
+  async store(authConfig: AuthConfig): Promise<void> {
+    await this.storeCredentialsInStore(authConfig);
+
+    delete authConfig.username;
+    delete authConfig.password;
+    delete authConfig.identitytoken;
+
+    return this.fileStore.store(authConfig);
+  }
+
+  isFileStore(): boolean {
+    return false;
+  }
+}

--- a/src/oci/config/credentials/store.ts
+++ b/src/oci/config/credentials/store.ts
@@ -1,0 +1,9 @@
+import { AuthConfig } from '../types/auth.ts';
+
+export interface Store {
+  erase(serverAddress: string): Promise<void>;
+  get(serverAddress: string): Promise<AuthConfig | undefined>;
+  getAll(): Promise<Record<string, AuthConfig>>;
+  store(authConfig: AuthConfig): Promise<void>;
+  isFileStore(): boolean;
+}

--- a/src/oci/config/types/auth.ts
+++ b/src/oci/config/types/auth.ts
@@ -1,0 +1,33 @@
+import { decode as base64Decode, encode as base64Encode } from 'https://deno.land/std@0.195.0/encoding/base64.ts';
+
+export type AuthConfig = {
+  username?: string;
+  password?: string;
+  auth?: string;
+  email?: string;
+  serveraddress?: string;
+  identitytoken?: string;
+  registrytoken?: string;
+};
+
+export const encodeAuth = (config: AuthConfig): string => {
+  if (!config.username || !config.password) {
+    return '';
+  }
+
+  return base64Encode(`${config.username}:${config.password}`);
+};
+
+export const decodeAuth = (auth: string): { username: string; password: string } => {
+  if (!auth) {
+    return { username: '', password: '' };
+  }
+
+  const decoded = new TextDecoder().decode(base64Decode(auth));
+  const parts = decoded.split(':');
+  if (parts.length !== 2) {
+    throw new Error(`auth ${decoded} does not conform to the base64(username:password) format`);
+  }
+
+  return { username: parts[0], password: parts[1] };
+};

--- a/src/oci/image-repository.ts
+++ b/src/oci/image-repository.ts
@@ -259,7 +259,6 @@ export class ImageRepository<C extends any = any> {
         digest: res.headers.get('docker-content-digest')!,
       };
     } catch (err) {
-      console.error(err);
       throw new Error('Failed to upload blob to registry');
     }
   }


### PR DESCRIPTION
## Description

This PR improves the OCI library to read from the docker configuration file (default location of `~/.docker/config.json`) to collect and utilize credentials to authenticate with private registries. You'll still need to log into the registry using `docker login` for now, but this PR will ensure that `arcctl push <component-tag>` will successfully push artifacts to registries like Dockerhub that you're logged in to.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Make sure you have a dockerhub account before you begin:

```sh
$ docker login
$ git clone git@github.com:architect-team/mailslurper.git && cd mailslurper
$ arcctl build . -t <account>/<repo>:latest
$ arcctl push <account>/<repo>:latest
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
