### PR TITLE
Created github actions workflow to publish codecov report for main

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,40 @@
+name: Codecov
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DENO_DIR: deno_cache
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Deno
+        uses: denolib/setup-deno@master
+        with:
+          deno-version: 1.35.2
+      - name: Cache Deno dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: ${{ hashFiles('deno.lock') }}
+      - name: Check formatting
+        run: deno fmt --check
+      - name: Check linting
+        run: deno lint
+      - name: Run type checks
+        run: deno task typecheck
+      - name: Run unit tests
+        run: deno task test
+      - name: Generate coverage report
+        run: deno coverage ./coverage --lcov > coverage.lcov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
Our codecov reports are unable to produce valid diffs because there isn't a report for the main branch. This will publish a codecov report every time changes are merged to main to ensure we don't introduce regressions.
