### PR TITLE
Fixed two issues with remote component pulls

### DIFF
--- a/src/component-store/store.ts
+++ b/src/component-store/store.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'https://deno.land/std@0.153.0/node/buffer.ts';
 import * as crypto from 'https://deno.land/std@0.153.0/node/crypto.ts';
 import { copy } from 'std/fs/copy.ts';
 import { existsSync } from 'std/fs/exists.ts';
@@ -13,12 +12,6 @@ const CACHE_DB_FILENAME = 'component.db.json';
 
 enum MEDIA_TYPES {
   OCI_MANIFEST = 'application/vnd.oci.image.manifest.v1+json',
-}
-
-interface BinaryData {
-  digest: string;
-  size: number;
-  data: Buffer;
 }
 
 export interface VolumeConfig {

--- a/src/components/v2/index.ts
+++ b/src/components/v2/index.ts
@@ -328,12 +328,17 @@ export default class ComponentV2 extends Component {
         );
       }
       for (const [volumeKey, volumeConfig] of Object.entries(volumes)) {
-        const is_directory = Deno.statSync(context.component.source).isDirectory;
         let host_path = undefined;
-        if (volumeConfig.host_path && !is_directory) {
-          host_path = path.join(path.dirname(context.component.source), volumeConfig.host_path);
-        } else if (volumeConfig.host_path) {
-          host_path = path.join(context.component.source, volumeConfig.host_path);
+
+        try {
+          const is_directory = Deno.statSync(context.component.source).isDirectory;
+          if (volumeConfig.host_path && !is_directory) {
+            host_path = path.join(path.dirname(context.component.source), volumeConfig.host_path);
+          } else if (volumeConfig.host_path) {
+            host_path = path.join(context.component.source, volumeConfig.host_path);
+          }
+        } catch {
+          // Source is remote, so no host path
         }
 
         const volume_node = new CloudNode({

--- a/src/environments/v1/index.ts
+++ b/src/environments/v1/index.ts
@@ -263,7 +263,6 @@ export default class EnvironmentV1 extends Environment {
                 }
               }
             } catch (err) {
-              console.error(err);
               throw new Error(`Failed to load component: ${source}`);
             }
           } else if (component_config.source) {


### PR DESCRIPTION
## Description

Fixed two issues with remote component pulls:

1. Accidentally hardcoded the `Accept` header in my new fetch method to cite application/json which broke manifest pulls that expected a different media type. Fixed this.
2. Made the component v2 spec tolerant to component "source" values that weren't local. This specifically impacted attempts to do volume host mounts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```sh
$ arcctl apply dc local ...
$ arcctl apply env local -d local

# This previously errored when you didn't have `davidthor/mailslurper:latest` in your local cache
$ arcctl deploy davidthor/mailslurper:latest -e local
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
