### PR TITLE
Proxy create command to apply

### DIFF
--- a/src/commands/create/datacenter.ts
+++ b/src/commands/create/datacenter.ts
@@ -1,0 +1,5 @@
+import ApplyDatacenterCommand from '../apply/datacenter.ts';
+
+const CreateDatacenterCommand = ApplyDatacenterCommand;
+
+export default CreateDatacenterCommand;

--- a/src/commands/create/environment.ts
+++ b/src/commands/create/environment.ts
@@ -1,0 +1,5 @@
+import ApplyEnvironmentCommand from '../apply/environment.ts';
+
+const CreateEnvironmentCommand = ApplyEnvironmentCommand;
+
+export default CreateEnvironmentCommand;

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -1,5 +1,11 @@
+import CreateDatacenterCommand from './datacenter.ts';
+import CreateEnvironmentCommand from './environment.ts';
 import CreateResourceCommand from './resource.ts';
 
 const CreateCommands = CreateResourceCommand;
+
+// Aliases are handled by the apply command setup. All aliases are applied to the create command.
+CreateCommands.command('datacenter', CreateDatacenterCommand);
+CreateCommands.command('environment', CreateEnvironmentCommand);
 
 export default CreateCommands;


### PR DESCRIPTION
## Description

It is common for us to run `create` when we mean `apply`. This proxies the `create` to the `apply` command so things just work.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Just run the commands
```
arcctl create dc dopreview ./datacenter.yml --verbose
arcctl create env preview1 -d dopreview
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
