### PR TITLE
Only show providers that support secrets

### DIFF
--- a/src/commands/set/state-backend.ts
+++ b/src/commands/set/state-backend.ts
@@ -17,13 +17,25 @@ const SetStateBackendCommand = BaseCommand()
   .option('--creds <creds:string>', 'A key value pair of credentials to use for the provider', { collect: true })
   .action(set_state_backend);
 
+function getSecretProviderTypes(): string[] {
+  const results = [];
+  for (const [name, providerType] of Object.entries(SupportedProviders)) {
+    const provider = new providerType('test', {} as any, {} as any, {});
+    const service = (provider.resources as any)['secret'];
+    if (service) {
+      results.push(name);
+    }
+  }
+  return results;
+}
+
 async function set_state_backend(options: SetStateBackendOptions) {
   const command_helper = new CommandHelper(options);
 
   const providerName = options.provider ||
     (await Inputs.promptSelection({
       message: 'What provider will this account connect to?',
-      options: Object.keys(SupportedProviders),
+      options: getSecretProviderTypes(),
     }));
 
   const providerType = providerName as keyof typeof SupportedProviders;


### PR DESCRIPTION
## Description

When selecting a backend only show providers that support secrets.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Check only local and s3 show up when setting the backend state.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
