### PR TITLE
Fixed issue with oci image format regex

### DIFF
--- a/src/oci/utils.ts
+++ b/src/oci/utils.ts
@@ -16,4 +16,4 @@ export const fileToBinaryData = async (file: string): Promise<BinaryData> => {
 };
 
 export const IMAGE_REGEXP =
-  /^(?:((?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)+|localhost)(?::[0-9]{1,5})?)\/)?([a-zA-Z0-9]+(?:\/[a-zA-Z0-9]+)*)(:[a-zA-Z0-9][a-zA-Z0-9_.-]*|@[a-zA-Z0-9]+:[a-fA-F0-9]+)?$/;
+  /^(?:((?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)+|localhost)(?::[0-9]{1,5})?)\/)?([a-zA-Z0-9]+(?:\/[a-zA-Z0-9_-]+)*)(:[a-zA-Z0-9][a-zA-Z0-9_.-]*|@[a-zA-Z0-9]+:[a-fA-F0-9]+)?$/;


### PR DESCRIPTION
The IMAGE_REGEXP expression, used to tests OCI image tag formats, did not support hyphens or underscores in the repo name. This fixes that.
