### PR TITLE
Only add a create step if the previous action is create

### DIFF
--- a/src/pipeline/pipeline.ts
+++ b/src/pipeline/pipeline.ts
@@ -293,7 +293,7 @@ export class Pipeline {
 
       const oldId = newNode.id;
       if (
-        !previousStep || previousStep.status.state !== 'complete' ||
+        !previousStep || (previousStep.status.state !== 'complete' && previousStep.action === 'create') ||
         previousStep.action === 'delete'
       ) {
         const newStep = new PipelineStep({


### PR DESCRIPTION
If the previous action was `'update`' and it wasn't completed (because of an error so eomthing), we were adding a new `create` step for that node. This causes an already existing node to be "created" again which will very likely error.