### PR TITLE
Get environment command

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+component_management:
+  individual_components:
+    - component_id: graph
+      paths:
+        - src/cloud-graph
+    - component_id: pipeline
+      paths:
+        - src/pipeline
+    - component_id: components
+      paths:
+        - src/components
+    - component_id: environments
+      paths:
+        - src/environments
+    - component_id: datacenters
+      paths:
+        - src/datacenters
+    - component_id: component-store
+      paths:
+        - src/component-store
+        - src/oci
+    - component_id: state
+      paths:
+        - src/secrets
+
+ignore:
+  - src/@providers
+
+comment:
+  layout: "header, diff, components, files" # show component info in the PR comment

--- a/src/@providers/kubernetes/provider.ts
+++ b/src/@providers/kubernetes/provider.ts
@@ -22,7 +22,7 @@ export default class KubernetesProvider extends Provider<KubernetesCredentials> 
 
   public async testCredentials(): Promise<boolean> {
     try {
-      const { code, stdout } = await kubectlExec(this.credentials, ['version']);
+      const { code, stdout } = await kubectlExec(this.credentials, ['version', '--request-timeout', '5s']);
       if (code !== 0) {
         return false;
       }

--- a/src/@providers/postgres/provider.ts
+++ b/src/@providers/postgres/provider.ts
@@ -18,7 +18,7 @@ export default class PostgresProvider extends Provider<PostgresCredentials> {
     let failureCount = 0;
     while (failureCount < 3) {
       try {
-        const client = getPgClient(this.credentials);
+        const client = getPgClient(this.credentials, { connectionTimeout: 1000 });
 
         await client.connect();
         await client.query('SELECT NOW()');

--- a/src/@providers/postgres/utils.ts
+++ b/src/@providers/postgres/utils.ts
@@ -1,12 +1,13 @@
 import { pg } from 'deps';
 import { PostgresCredentials } from './credentials.ts';
 
-export function getPgClient(credentials: PostgresCredentials): pg.Client {
+export function getPgClient(credentials: PostgresCredentials, options?: { connectionTimeout?: number }): pg.Client {
   return new pg.Client({
     host: credentials.host === 'host.docker.internal' ? 'localhost' : credentials.host,
     port: credentials.port,
     user: credentials.username,
     password: credentials.password,
     database: credentials.database,
+    connectionTimeoutMillis: options?.connectionTimeout,
   });
 }

--- a/src/commands/get/environment.ts
+++ b/src/commands/get/environment.ts
@@ -1,0 +1,26 @@
+import yaml from 'js-yaml';
+import { BaseCommand, CommandHelper, GlobalOptions } from '../base-command.ts';
+
+const GetEnvironmentConfigCommand = BaseCommand()
+  .description('Retrieve the environment matching the specified name')
+  .arguments('<name:string>')
+  .action(getEnvironmentConfigAction);
+
+async function getEnvironmentConfigAction(options: GlobalOptions, name: string) {
+  const command_helper = new CommandHelper(options);
+
+  try {
+    const environmentRecord = await command_helper.environmentStore.get(name);
+    if (!environmentRecord) {
+      console.error(`%cEnvironment "${name}" not found`, 'color: red');
+      Deno.exit(1);
+    }
+
+    console.log(yaml.dump(environmentRecord.config));
+  } catch (err: any) {
+    console.error(err);
+    Deno.exit(1);
+  }
+}
+
+export default GetEnvironmentConfigCommand;

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -1,10 +1,12 @@
 import GetAccountCommand from './account.ts';
 import GetComponentCommand from './component.ts';
+import GetEnvironmentCommand from './environment.ts';
 import GetResourceCommand from './resource.ts';
 
 const GetCommands = GetResourceCommand;
 
 GetCommands.command('account', GetAccountCommand.alias('accounts'));
 GetCommands.command('component', GetComponentCommand.alias('components'));
+GetCommands.command('environment', GetEnvironmentCommand.alias('environments'));
 
 export default GetCommands;


### PR DESCRIPTION
## Description

1. Added `get environment` command to dump the stored environment configuration. I needed this to more easily debug how the deploy command impacts the environment config file.
2. Fixed some issues with testCredentials() for both the postgres and kubernetes providers. They didn't timeout correctly when connections were taking a long time which made it really hard to `prune` bad accounts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
