### PR TITLE
Fixed issue with updating secrets in the local provider

### DIFF
--- a/src/@providers/docker/services/deployment.ts
+++ b/src/@providers/docker/services/deployment.ts
@@ -91,7 +91,7 @@ export class DockerDeploymentService extends CrudResourceService<'deployment', D
   }
 
   async create(
-    _subscriber: Subscriber<string>,
+    subscriber: Subscriber<string>,
     inputs: ResourceInputs['deployment'],
   ): Promise<ResourceOutputs['deployment']> {
     let containerName = inputs.name.replaceAll('/', '--');
@@ -181,6 +181,8 @@ export class DockerDeploymentService extends CrudResourceService<'deployment', D
       }
     }
 
+    subscriber.next('');
+
     return {
       id: containerName,
       labels,
@@ -197,7 +199,7 @@ export class DockerDeploymentService extends CrudResourceService<'deployment', D
       throw new Error(`No deployment with ID ${id}`);
     }
 
-    subscriber.next(`Stopping old container: ${inspection.Id}`);
+    subscriber.next('Stopping old container');
 
     const { code: stopCode, stderr: stopStderr } = await exec('docker', { args: ['stop', inspection.Id] });
     if (stopCode !== 0) {
@@ -209,7 +211,7 @@ export class DockerDeploymentService extends CrudResourceService<'deployment', D
       throw new Error(rmStderr);
     }
 
-    subscriber.next(`Starting new container`);
+    subscriber.next('Starting new container');
 
     return this.create(subscriber, inputs as ResourceInputs['deployment']);
   }
@@ -217,7 +219,6 @@ export class DockerDeploymentService extends CrudResourceService<'deployment', D
   async delete(subscriber: Subscriber<string>, id: string): Promise<void> {
     const match = await this.get(id);
     if (!match) {
-      subscriber.next('No matching deployment. Skipping.');
       return Promise.resolve();
     }
 

--- a/src/@providers/traefik/services/service.ts
+++ b/src/@providers/traefik/services/service.ts
@@ -306,11 +306,11 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
     };
 
     if (normalizedNewId !== normalizedPreviousId) {
-      subscriber.next('Removing old service: ' + normalizedPreviousId);
+      subscriber.next('Removing old service');
       await this.taskService.deleteFile(path.join(MOUNT_PATH, normalizedPreviousId + FILE_SUFFIX));
     }
 
-    subscriber.next('Registering new service: ' + normalizedNewId);
+    subscriber.next('Registering new service');
     await this.taskService.writeFile(path.join(MOUNT_PATH, normalizedNewId + FILE_SUFFIX), yaml.dump(newEntry));
 
     const port = 80;
@@ -325,6 +325,7 @@ export class TraefikServiceService extends CrudResourceService<'service', Traefi
       url += `:${port}`;
     }
 
+    subscriber.next('');
     return {
       ...newEntry.architect,
       id: normalizedNewId,

--- a/src/commands/apply/utils.ts
+++ b/src/commands/apply/utils.ts
@@ -13,6 +13,7 @@ export type ApplyEnvironmentOptions = {
   datacenter?: string;
   logger?: Logger;
   autoApprove?: boolean;
+  debug?: boolean;
 };
 
 export const promptForDatacenter = async (command_helper: CommandHelper, name?: string): Promise<DatacenterRecord> => {
@@ -59,7 +60,11 @@ export const applyEnvironment = async (options: ApplyEnvironmentOptions) => {
 
   const targetEnvironment = options.targetEnvironment || await parseEnvironment({});
 
-  let targetGraph = await targetEnvironment.getGraph(options.name, options.command_helper.componentStore);
+  let targetGraph = await targetEnvironment.getGraph(
+    options.name,
+    options.command_helper.componentStore,
+    options.debug,
+  );
   targetGraph = await targetDatacenter.config.enrichGraph(targetGraph, {
     environmentName: options.name,
     datacenterName: targetDatacenter.name,

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -108,7 +108,7 @@ async function up_action(options: UpOptions, ...components: string[]): Promise<v
     throw new Error('Either a datacenter or environment must be specified');
   }
 
-  const originalEnvironment = await parseEnvironment({ ...environment });
+  const originalEnvironment = await parseEnvironment(JSON.parse(JSON.stringify(environment)));
 
   for (let tag_or_path of resolvedComponents) {
     let componentPath: string | undefined;
@@ -190,6 +190,7 @@ async function up_action(options: UpOptions, ...components: string[]): Promise<v
           name: environmentRecord.name,
           targetEnvironment: originalEnvironment,
           command_helper,
+          debug: options.debug,
         });
       } else {
         await destroyEnvironment({ verbose: options.verbose, autoApprove: true }, envName);
@@ -207,6 +208,7 @@ async function up_action(options: UpOptions, ...components: string[]): Promise<v
         name: environmentRecord.name,
         targetEnvironment: originalEnvironment,
         command_helper,
+        debug: options.debug,
       });
     } else {
       await destroyEnvironment({ verbose: options.verbose, autoApprove: true }, envName);


### PR DESCRIPTION
## Description

This actually fixes two issues:

1. Updating secrets in the local provider was accidentally deleting the secret instead of updating it. Fixed.
2. The up command wasn't reverting to the previous environment state correctly upon completion. Fixed.
3. Debug flag wasn't being used during cleanup step of up command which was leading to resource changes that didn't make sense. Fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
