### PR TITLE
updating to allow multiple dev plugins, adding force datacenter destroy flag

### DIFF
--- a/src/datacenter-modules/server.ts
+++ b/src/datacenter-modules/server.ts
@@ -5,11 +5,13 @@ export class ModuleServer {
   private plugin: Plugin;
   private proc?: Deno.ChildProcess;
   private containerName?: string;
-  private dev_plugin_port?: string;
+  private dev_pulumi_plugin_port?: string;
+  private dev_opentofu_plugin_port?: string;
 
   constructor(plugin: Plugin) {
     this.plugin = plugin;
-    this.dev_plugin_port = Deno.env.get('DEV_PLUGIN_PORT');
+    this.dev_pulumi_plugin_port = Deno.env.get('DEV_PULUMI_PLUGIN_PORT');
+    this.dev_opentofu_plugin_port = Deno.env.get('DEV_OPENTOFU_PLUGIN_PORT');
   }
 
   private async getPort(containerName: string): Promise<number> {
@@ -31,8 +33,10 @@ export class ModuleServer {
     const pluginImage = `architectio/${this.plugin}-plugin`;
     this.containerName = pluginImage.replace('/', '-') + '-' + Date.now();
 
-    if (this.dev_plugin_port) {
-      return new ModuleClient(parseInt(this.dev_plugin_port));
+    if (this.dev_pulumi_plugin_port && this.plugin === 'pulumi') {
+      return new ModuleClient(parseInt(this.dev_pulumi_plugin_port));
+    } else if (this.dev_opentofu_plugin_port && this.plugin === 'opentofu') {
+      return new ModuleClient(parseInt(this.dev_opentofu_plugin_port));
     }
 
     const command = new Deno.Command('docker', {
@@ -83,7 +87,7 @@ export class ModuleServer {
   }
 
   async stop(): Promise<void> {
-    if (this.dev_plugin_port) {
+    if (this.dev_pulumi_plugin_port || this.dev_opentofu_plugin_port) {
       return; // dev plugin server was run directly and shouldn't be stopped
     }
     const command = new Deno.Command('docker', {


### PR DESCRIPTION
The changes here allow for the OpenTofu and Pulumi plugins to be used simultaneously in development mode. To use a plugin in development mode, set a port number for the value of `DEV_PULUMI_PLUGIN_PORT` and/or `DEV_OPENTOFU_PLUGIN_PORT` in the same terminal that `arcctl` commands are run. 

The changes here also include a `--force` flag for the `datacenter destroy` command, where if the command fails for whatever reason, the datacenter record will still be cleaned up. This prevents dangling datacenter records.