### PR TITLE
Module images - build from github, build and push modules separately from DC

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.35.2
+          deno-version: 1.38.1
       - name: Cache Deno dependencies
         uses: actions/cache@v3
         with:

--- a/deno.lock
+++ b/deno.lock
@@ -2,99 +2,12 @@
   "version": "3",
   "packages": {
     "specifiers": {
-      "npm:@types/node": "npm:@types/node@18.16.19",
-      "npm:@types/pg@^8.6.5": "npm:@types/pg@8.10.9",
-      "npm:mustache": "npm:mustache@4.2.0",
-      "npm:pg@8.8.0": "npm:pg@8.8.0",
-      "npm:ts-json-schema-generator": "npm:ts-json-schema-generator@1.2.0"
+      "npm:pg@8.8.0": "npm:pg@8.8.0"
     },
     "npm": {
-      "@types/json-schema@7.0.12": {
-        "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
-        "dependencies": {}
-      },
-      "@types/node@18.16.19": {
-        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
-        "dependencies": {}
-      },
-      "@types/pg@8.10.9": {
-        "integrity": "sha512-UksbANNE/f8w0wOMxVKKIrLCbEMV+oM1uKejmwXr39olg4xqcfBDbXxObJAt6XxHbDa4XTKOlUEcEltXDX+XLQ==",
-        "dependencies": {
-          "@types/node": "@types/node@18.16.19",
-          "pg-protocol": "pg-protocol@1.6.0",
-          "pg-types": "pg-types@4.0.1"
-        }
-      },
-      "balanced-match@1.0.2": {
-        "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-        "dependencies": {}
-      },
-      "brace-expansion@2.0.1": {
-        "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-        "dependencies": {
-          "balanced-match": "balanced-match@1.0.2"
-        }
-      },
       "buffer-writer@2.0.0": {
         "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
         "dependencies": {}
-      },
-      "commander@9.5.0": {
-        "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-        "dependencies": {}
-      },
-      "fs.realpath@1.0.0": {
-        "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-        "dependencies": {}
-      },
-      "glob@8.1.0": {
-        "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-        "dependencies": {
-          "fs.realpath": "fs.realpath@1.0.0",
-          "inflight": "inflight@1.0.6",
-          "inherits": "inherits@2.0.4",
-          "minimatch": "minimatch@5.1.6",
-          "once": "once@1.4.0"
-        }
-      },
-      "inflight@1.0.6": {
-        "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-        "dependencies": {
-          "once": "once@1.4.0",
-          "wrappy": "wrappy@1.0.2"
-        }
-      },
-      "inherits@2.0.4": {
-        "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-        "dependencies": {}
-      },
-      "json5@2.2.3": {
-        "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-        "dependencies": {}
-      },
-      "minimatch@5.1.6": {
-        "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-        "dependencies": {
-          "brace-expansion": "brace-expansion@2.0.1"
-        }
-      },
-      "mustache@4.2.0": {
-        "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-        "dependencies": {}
-      },
-      "normalize-path@3.0.0": {
-        "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-        "dependencies": {}
-      },
-      "obuf@1.1.2": {
-        "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-        "dependencies": {}
-      },
-      "once@1.4.0": {
-        "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-        "dependencies": {
-          "wrappy": "wrappy@1.0.2"
-        }
       },
       "packet-reader@1.0.0": {
         "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
@@ -106,10 +19,6 @@
       },
       "pg-int8@1.0.1": {
         "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-        "dependencies": {}
-      },
-      "pg-numeric@1.0.2": {
-        "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
         "dependencies": {}
       },
       "pg-pool@3.6.1_pg@8.8.0": {
@@ -130,18 +39,6 @@
           "postgres-bytea": "postgres-bytea@1.0.0",
           "postgres-date": "postgres-date@1.0.7",
           "postgres-interval": "postgres-interval@1.2.0"
-        }
-      },
-      "pg-types@4.0.1": {
-        "integrity": "sha512-hRCSDuLII9/LE3smys1hRHcu5QGcLs9ggT7I/TCs0IE+2Eesxi9+9RWAAwZ0yaGjxoWICF/YHLOEjydGujoJ+g==",
-        "dependencies": {
-          "pg-int8": "pg-int8@1.0.1",
-          "pg-numeric": "pg-numeric@1.0.2",
-          "postgres-array": "postgres-array@3.0.2",
-          "postgres-bytea": "postgres-bytea@3.0.0",
-          "postgres-date": "postgres-date@2.0.1",
-          "postgres-interval": "postgres-interval@3.0.0",
-          "postgres-range": "postgres-range@1.1.3"
         }
       },
       "pg@8.8.0": {
@@ -166,26 +63,12 @@
         "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
         "dependencies": {}
       },
-      "postgres-array@3.0.2": {
-        "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-        "dependencies": {}
-      },
       "postgres-bytea@1.0.0": {
         "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
         "dependencies": {}
       },
-      "postgres-bytea@3.0.0": {
-        "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-        "dependencies": {
-          "obuf": "obuf@1.1.2"
-        }
-      },
       "postgres-date@1.0.7": {
         "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-        "dependencies": {}
-      },
-      "postgres-date@2.0.1": {
-        "integrity": "sha512-YtMKdsDt5Ojv1wQRvUhnyDJNSr2dGIC96mQVKz7xufp07nfuFONzdaowrMHjlAzY6GDLd4f+LUHHAAM1h4MdUw==",
         "dependencies": {}
       },
       "postgres-interval@1.2.0": {
@@ -194,40 +77,8 @@
           "xtend": "xtend@4.0.2"
         }
       },
-      "postgres-interval@3.0.0": {
-        "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-        "dependencies": {}
-      },
-      "postgres-range@1.1.3": {
-        "integrity": "sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==",
-        "dependencies": {}
-      },
-      "safe-stable-stringify@2.4.3": {
-        "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-        "dependencies": {}
-      },
       "split2@4.2.0": {
         "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-        "dependencies": {}
-      },
-      "ts-json-schema-generator@1.2.0": {
-        "integrity": "sha512-tUMeO3ZvA12d3HHh7T/AK8W5hmUhDRNtqWRHSMN3ZRbUFt+UmV0oX8k1RK4SA+a+BKNHpmW2v06MS49e8Fi3Yg==",
-        "dependencies": {
-          "@types/json-schema": "@types/json-schema@7.0.12",
-          "commander": "commander@9.5.0",
-          "glob": "glob@8.1.0",
-          "json5": "json5@2.2.3",
-          "normalize-path": "normalize-path@3.0.0",
-          "safe-stable-stringify": "safe-stable-stringify@2.4.3",
-          "typescript": "typescript@4.9.5"
-        }
-      },
-      "typescript@4.9.5": {
-        "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-        "dependencies": {}
-      },
-      "wrappy@1.0.2": {
-        "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
         "dependencies": {}
       },
       "xtend@4.0.2": {
@@ -236,34 +87,7 @@
       }
     }
   },
-  "redirects": {
-    "https://esm.sh/v124/@types/escodegen@latest/index.d.ts": "https://esm.sh/v124/@types/escodegen@0.0.9/index.d.ts",
-    "https://esm.sh/v124/@types/estraverse@^5/index.d.ts": "https://esm.sh/v124/@types/estraverse@5.1.4/index.d.ts",
-    "https://esm.sh/v124/@types/events@~1.1/index.d.ts": "https://esm.sh/v124/@types/events@1.1.0/index.d.ts",
-    "https://esm.sh/v124/@types/js-yaml@^4/index.d.ts": "https://esm.sh/v124/@types/js-yaml@4.0.5/index.d.ts",
-    "https://esm.sh/v124/@types/tar@^6/index.d.ts": "https://esm.sh/v124/@types/tar@6.1.6/index.d.ts"
-  },
   "remote": {
-    "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
-    "https://deno.land/std@0.140.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
-    "https://deno.land/std@0.140.0/bytes/bytes_list.ts": "67eb118e0b7891d2f389dad4add35856f4ad5faab46318ff99653456c23b025d",
-    "https://deno.land/std@0.140.0/bytes/equals.ts": "fc16dff2090cced02497f16483de123dfa91e591029f985029193dfaa9d894c9",
-    "https://deno.land/std@0.140.0/bytes/mod.ts": "763f97d33051cc3f28af1a688dfe2830841192a9fea0cbaa55f927b49d49d0bf",
-    "https://deno.land/std@0.140.0/fmt/colors.ts": "30455035d6d728394781c10755351742dd731e3db6771b1843f9b9e490104d37",
-    "https://deno.land/std@0.140.0/fs/_util.ts": "0fb24eb4bfebc2c194fb1afdb42b9c3dda12e368f43e8f2321f84fc77d42cb0f",
-    "https://deno.land/std@0.140.0/fs/ensure_dir.ts": "9dc109c27df4098b9fc12d949612ae5c9c7169507660dcf9ad90631833209d9d",
-    "https://deno.land/std@0.140.0/hash/sha256.ts": "803846c7a5a8a5a97f31defeb37d72f519086c880837129934f5d6f72102a8e8",
-    "https://deno.land/std@0.140.0/io/buffer.ts": "bd0c4bf53db4b4be916ca5963e454bddfd3fcd45039041ea161dbf826817822b",
-    "https://deno.land/std@0.140.0/path/_constants.ts": "df1db3ffa6dd6d1252cc9617e5d72165cd2483df90e93833e13580687b6083c3",
-    "https://deno.land/std@0.140.0/path/_interface.ts": "ee3b431a336b80cf445441109d089b70d87d5e248f4f90ff906820889ecf8d09",
-    "https://deno.land/std@0.140.0/path/_util.ts": "c1e9686d0164e29f7d880b2158971d805b6e0efc3110d0b3e24e4b8af2190d2b",
-    "https://deno.land/std@0.140.0/path/common.ts": "bee563630abd2d97f99d83c96c2fa0cca7cee103e8cb4e7699ec4d5db7bd2633",
-    "https://deno.land/std@0.140.0/path/glob.ts": "cb5255638de1048973c3e69e420c77dc04f75755524cb3b2e160fe9277d939ee",
-    "https://deno.land/std@0.140.0/path/mod.ts": "d3e68d0abb393fb0bf94a6d07c46ec31dc755b544b13144dee931d8d5f06a52d",
-    "https://deno.land/std@0.140.0/path/posix.ts": "293cdaec3ecccec0a9cc2b534302dfe308adb6f10861fa183275d6695faace44",
-    "https://deno.land/std@0.140.0/path/separator.ts": "fe1816cb765a8068afb3e8f13ad272351c85cbc739af56dacfc7d93d710fe0f9",
-    "https://deno.land/std@0.140.0/path/win32.ts": "31811536855e19ba37a999cd8d1b62078235548d67902ece4aa6b814596dd757",
-    "https://deno.land/std@0.140.0/streams/conversion.ts": "712585bfa0172a97fb68dd46e784ae8ad59d11b88079d6a4ab098ff42e697d21",
     "https://deno.land/std@0.153.0/_deno_unstable.ts": "4ddb8672d49d58b5bbc4a5a7a2f1b3bce4fd06aa4c8b8476728334391667de7b",
     "https://deno.land/std@0.153.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.153.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
@@ -539,58 +363,11 @@
     "https://deno.land/std@0.177.0/node/internal_binding/uv.ts": "eb0048e30af4db407fb3f95563e30d70efd6187051c033713b0a5b768593a3a3",
     "https://deno.land/std@0.177.0/node/stream.ts": "09e348302af40dcc7dc58aa5e40fdff868d11d8d6b0cfb85cbb9c75b9fe450c7",
     "https://deno.land/std@0.177.0/node/string_decoder.ts": "1a17e3572037c512cc5fc4b29076613e90f225474362d18da908cb7e5ccb7e88",
-    "https://deno.land/std@0.181.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.181.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
-    "https://deno.land/std@0.181.0/bytes/bytes_list.ts": "b4cbdfd2c263a13e8a904b12d082f6177ea97d9297274a4be134e989450dfa6a",
-    "https://deno.land/std@0.181.0/bytes/concat.ts": "d26d6f3d7922e6d663dacfcd357563b7bf4a380ce5b9c2bbe0c8586662f25ce2",
-    "https://deno.land/std@0.181.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
-    "https://deno.land/std@0.181.0/bytes/ends_with.ts": "4228811ebc71615d27f065c54b5e815ec1972538772b0f413c0efe05245b472e",
-    "https://deno.land/std@0.181.0/bytes/equals.ts": "b87494ce5442dc786db46f91378100028c402f83a14a2f7bbff6bda7810aefe3",
-    "https://deno.land/std@0.181.0/bytes/includes_needle.ts": "76a8163126fb2f8bf86fd7f22192c3bb04bf6a20b987a095127c2ca08adf3ba6",
-    "https://deno.land/std@0.181.0/bytes/index_of_needle.ts": "65c939607df609374c4415598fa4dad04a2f14c4d98cd15775216f0aaf597f24",
-    "https://deno.land/std@0.181.0/bytes/last_index_of_needle.ts": "7181072883cb4908c6ce8f7a5bb1d96787eef2c2ab3aa94fe4268ab326a53cbf",
-    "https://deno.land/std@0.181.0/bytes/mod.ts": "e869bba1e7a2e3a9cc6c2d55471888429a544e70a840c087672e656e7ba21815",
-    "https://deno.land/std@0.181.0/bytes/repeat.ts": "6f5e490d8d72bcbf8d84a6bb04690b9b3eb5822c5a11687bca73a2318a842294",
-    "https://deno.land/std@0.181.0/bytes/starts_with.ts": "3e607a70c9c09f5140b7a7f17a695221abcc7244d20af3eb47ccbb63f5885135",
-    "https://deno.land/std@0.181.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.181.0/fs/_util.ts": "65381f341af1ff7f40198cee15c20f59951ac26e51ddc651c5293e24f9ce6f32",
-    "https://deno.land/std@0.181.0/fs/ensure_dir.ts": "dc64c4c75c64721d4e3fb681f1382f803ff3d2868f08563ff923fdd20d071c40",
-    "https://deno.land/std@0.181.0/fs/expand_glob.ts": "e4f56259a0a70fe23f05215b00de3ac5e6ba46646ab2a06ebbe9b010f81c972a",
-    "https://deno.land/std@0.181.0/fs/walk.ts": "ea95ffa6500c1eda6b365be488c056edc7c883a1db41ef46ec3bf057b1c0fe32",
-    "https://deno.land/std@0.181.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
-    "https://deno.land/std@0.181.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
-    "https://deno.land/std@0.181.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
-    "https://deno.land/std@0.181.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
-    "https://deno.land/std@0.181.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
-    "https://deno.land/std@0.181.0/path/mod.ts": "bf718f19a4fdd545aee1b06409ca0805bd1b68ecf876605ce632e932fe54510c",
-    "https://deno.land/std@0.181.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
-    "https://deno.land/std@0.181.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
-    "https://deno.land/std@0.181.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
-    "https://deno.land/std@0.181.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.181.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.181.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
-    "https://deno.land/std@0.182.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
-    "https://deno.land/std@0.182.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
-    "https://deno.land/std@0.182.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.182.0/fs/_util.ts": "65381f341af1ff7f40198cee15c20f59951ac26e51ddc651c5293e24f9ce6f32",
-    "https://deno.land/std@0.182.0/fs/empty_dir.ts": "c3d2da4c7352fab1cf144a1ecfef58090769e8af633678e0f3fabaef98594688",
-    "https://deno.land/std@0.182.0/fs/expand_glob.ts": "e4f56259a0a70fe23f05215b00de3ac5e6ba46646ab2a06ebbe9b010f81c972a",
-    "https://deno.land/std@0.182.0/fs/walk.ts": "920be35a7376db6c0b5b1caf1486fb962925e38c9825f90367f8f26b5e5d0897",
-    "https://deno.land/std@0.182.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
-    "https://deno.land/std@0.182.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
-    "https://deno.land/std@0.182.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
-    "https://deno.land/std@0.182.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
-    "https://deno.land/std@0.182.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
-    "https://deno.land/std@0.182.0/path/mod.ts": "bf718f19a4fdd545aee1b06409ca0805bd1b68ecf876605ce632e932fe54510c",
-    "https://deno.land/std@0.182.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
-    "https://deno.land/std@0.182.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
-    "https://deno.land/std@0.182.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
     "https://deno.land/std@0.192.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
     "https://deno.land/std@0.192.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
     "https://deno.land/std@0.192.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
     "https://deno.land/std@0.192.0/collections/_utils.ts": "5114abc026ddef71207a79609b984614e66a63a4bda17d819d56b0e72c51527e",
     "https://deno.land/std@0.192.0/collections/deep_merge.ts": "5a8ed29030f4471a5272785c57c3455fa79697b9a8f306013a8feae12bafc99a",
-    "https://deno.land/std@0.192.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
     "https://deno.land/std@0.192.0/fs/_util.ts": "fbf57dcdc9f7bc8128d60301eece608246971a7836a3bb1e78da75314f08b978",
     "https://deno.land/std@0.192.0/fs/copy.ts": "14214efd94fc3aa6db1e4af2b4b9578e50f7362b7f3725d5a14ad259a5df26c8",
     "https://deno.land/std@0.192.0/fs/ensure_dir.ts": "dc64c4c75c64721d4e3fb681f1382f803ff3d2868f08563ff923fdd20d071c40",
@@ -605,12 +382,6 @@
     "https://deno.land/std@0.192.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
     "https://deno.land/std@0.192.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
     "https://deno.land/std@0.192.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba",
-    "https://deno.land/std@0.192.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.192.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.192.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
-    "https://deno.land/std@0.192.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
-    "https://deno.land/std@0.192.0/testing/bdd.ts": "59f7f7503066d66a12e50ace81bfffae5b735b6be1208f5684b630ae6b4de1d0",
-    "https://deno.land/std@0.192.0/testing/mock.ts": "220ed9b8151cb2cac141043d4cfea7c47673fab5d18d1c1f0943297c8afb5d13",
     "https://deno.land/std@0.195.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
     "https://deno.land/std@0.195.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
     "https://deno.land/std@0.195.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
@@ -633,7 +404,6 @@
     "https://deno.land/std@0.50.0/path/posix.ts": "b742fe902d5d6821c39c02319eb32fc5a92b4d4424b533c47f1a50610afbf381",
     "https://deno.land/x/cliffy@v0.25.7/_utils/distance.ts": "02af166952c7c358ac83beae397aa2fbca4ad630aecfcd38d92edb1ea429f004",
     "https://deno.land/x/cliffy@v0.25.7/ansi/ansi_escapes.ts": "885f61f343223f27b8ec69cc138a54bea30542924eacd0f290cd84edcf691387",
-    "https://deno.land/x/cliffy@v0.25.7/ansi/chain.ts": "31fb9fcbf72fed9f3eb9b9487270d2042ccd46a612d07dd5271b1a80ae2140a0",
     "https://deno.land/x/cliffy@v0.25.7/ansi/colors.ts": "5f71993af5bd1aa0a795b15f41692d556d7c89584a601fed75997df844b832c9",
     "https://deno.land/x/cliffy@v0.25.7/ansi/cursor_position.ts": "d537491e31d9c254b208277448eff92ff7f55978c4928dea363df92c0df0813f",
     "https://deno.land/x/cliffy@v0.25.7/ansi/deps.ts": "0f35cb7e91868ce81561f6a77426ea8bc55dc15e13f84c7352f211023af79053",
@@ -683,7 +453,6 @@
     "https://deno.land/x/cliffy@v0.25.7/flags/types/string.ts": "e89b6a5ce322f65a894edecdc48b44956ec246a1d881f03e97bbda90dd8638c5",
     "https://deno.land/x/cliffy@v0.25.7/keycode/key_code.ts": "c4ab0ffd102c2534962b765ded6d8d254631821bf568143d9352c1cdcf7a24be",
     "https://deno.land/x/cliffy@v0.25.7/keycode/key_codes.ts": "917f0a2da0dbace08cf29bcfdaaa2257da9fe7e705fff8867d86ed69dfb08cfe",
-    "https://deno.land/x/cliffy@v0.25.7/keycode/mod.ts": "292d2f295316c6e0da6955042a7b31ab2968ff09f2300541d00f05ed6c2aa2d4",
     "https://deno.land/x/cliffy@v0.25.7/prompt/_generic_input.ts": "737cff2de02c8ce35250f5dd79c67b5fc176423191a2abd1f471a90dd725659e",
     "https://deno.land/x/cliffy@v0.25.7/prompt/_generic_list.ts": "79b301bf09eb19f0d070d897f613f78d4e9f93100d7e9a26349ef0bfaa7408d2",
     "https://deno.land/x/cliffy@v0.25.7/prompt/_generic_prompt.ts": "8630ce89a66d83e695922df41721cada52900b515385d86def597dea35971bb2",
@@ -709,44 +478,8 @@
     "https://deno.land/x/cliffy@v0.25.7/table/row.ts": "5f519ba7488d2ef76cbbf50527f10f7957bfd668ce5b9169abbc44ec88302645",
     "https://deno.land/x/cliffy@v0.25.7/table/table.ts": "ec204c9d08bb3ff1939c5ac7412a4c9ed7d00925d4fc92aff9bfe07bd269258d",
     "https://deno.land/x/cliffy@v0.25.7/table/utils.ts": "187bb7dcbcfb16199a5d906113f584740901dfca1007400cba0df7dcd341bc29",
-    "https://deno.land/x/code_block_writer@12.0.0/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",
-    "https://deno.land/x/code_block_writer@12.0.0/utils/string_utils.ts": "60cb4ec8bd335bf241ef785ccec51e809d576ff8e8d29da43d2273b69ce2a6ff",
-    "https://deno.land/x/deno_cache@0.4.1/auth_tokens.ts": "5fee7e9155e78cedf3f6ff3efacffdb76ac1a76c86978658d9066d4fb0f7326e",
-    "https://deno.land/x/deno_cache@0.4.1/cache.ts": "51f72f4299411193d780faac8c09d4e8cbee951f541121ef75fcc0e94e64c195",
-    "https://deno.land/x/deno_cache@0.4.1/deno_dir.ts": "f2a9044ce8c7fe1109004cda6be96bf98b08f478ce77e7a07f866eff1bdd933f",
-    "https://deno.land/x/deno_cache@0.4.1/deps.ts": "8974097d6c17e65d9a82d39377ae8af7d94d74c25c0cbb5855d2920e063f2343",
-    "https://deno.land/x/deno_cache@0.4.1/dirs.ts": "d2fa473ef490a74f2dcb5abb4b9ab92a48d2b5b6320875df2dee64851fa64aa9",
-    "https://deno.land/x/deno_cache@0.4.1/disk_cache.ts": "1f3f5232cba4c56412d93bdb324c624e95d5dd179d0578d2121e3ccdf55539f9",
-    "https://deno.land/x/deno_cache@0.4.1/file_fetcher.ts": "07a6c5f8fd94bf50a116278cc6012b4921c70d2251d98ce1c9f3c352135c39f7",
-    "https://deno.land/x/deno_cache@0.4.1/http_cache.ts": "f632e0d6ec4a5d61ae3987737a72caf5fcdb93670d21032ddb78df41131360cd",
-    "https://deno.land/x/deno_cache@0.4.1/mod.ts": "ef1cda9235a93b89cb175fe648372fc0f785add2a43aa29126567a05e3e36195",
-    "https://deno.land/x/deno_cache@0.4.1/util.ts": "8cb686526f4be5205b92c819ca2ce82220aa0a8dd3613ef0913f6dc269dbbcfe",
     "https://deno.land/x/dir@1.5.1/home_dir/mod.ts": "53777e4fb2586ae02ce94adf2c99f2edb2dcf6e72d07ac289b71593cfacbdbbf",
-    "https://deno.land/x/dnt@0.36.0/lib/compiler.ts": "209ad2e1b294f93f87ec02ade9a0821f942d2e524104552d0aa8ff87021050a5",
-    "https://deno.land/x/dnt@0.36.0/lib/compiler_transforms.ts": "cbb1fd5948f5ced1aa5c5aed9e45134e2357ce1e7220924c1d7bded30dcd0dd0",
-    "https://deno.land/x/dnt@0.36.0/lib/mod.deps.ts": "30367fc68bcd2acf3b7020cf5cdd26f817f7ac9ac35c4bfb6c4551475f91bc3e",
-    "https://deno.land/x/dnt@0.36.0/lib/npm_ignore.ts": "b430caa1905b65ae89b119d84857b3ccc3cb783a53fc083d1970e442f791721d",
-    "https://deno.land/x/dnt@0.36.0/lib/package_json.ts": "61f35b06e374ed39ca776d29d67df4be7ee809d0bca29a8239687556c6d027c2",
-    "https://deno.land/x/dnt@0.36.0/lib/pkg/dnt_wasm.generated.js": "1f21e46f32209d8746fd5c7d3bc8f25c2cbebe1d9da4ef083eca1b621eb72598",
-    "https://deno.land/x/dnt@0.36.0/lib/pkg/snippets/dnt-wasm-a15ef721fa5290c5/helpers.js": "a6b95adc943a68d513fe8ed9ec7d260ac466b7a4bced4e942f733e494bb9f1be",
-    "https://deno.land/x/dnt@0.36.0/lib/shims.ts": "df1bd4d9a196dca4b2d512b1564fff64ac6c945189a273d706391f87f210d7e6",
-    "https://deno.land/x/dnt@0.36.0/lib/test_runner/get_test_runner_code.ts": "4dc7a73a13b027341c0688df2b29a4ef102f287c126f134c33f69f0339b46968",
-    "https://deno.land/x/dnt@0.36.0/lib/test_runner/test_runner.ts": "4d0da0500ec427d5f390d9a8d42fb882fbeccc92c92d66b6f2e758606dbd40e6",
-    "https://deno.land/x/dnt@0.36.0/lib/transform.deps.ts": "e42f2bdef46d098453bdba19261a67cf90b583f5d868f7fe83113c1380d9b85c",
-    "https://deno.land/x/dnt@0.36.0/lib/types.ts": "b8e228b2fac44c2ae902fbb73b1689f6ab889915bd66486c8a85c0c24255f5fb",
-    "https://deno.land/x/dnt@0.36.0/lib/utils.ts": "878b7ac7003a10c16e6061aa49dbef9b42bd43174853ebffc9b67ea47eeb11d8",
-    "https://deno.land/x/dnt@0.36.0/mod.ts": "670f1820f2115e6b6aa4f79999bc796e30cc0d0b45096b84a4e1db9f62b82984",
-    "https://deno.land/x/dnt@0.36.0/transform.ts": "1b127c5f22699c8ab2545b98aeca38c4e5c21405b0f5342ea17e9c46280ed277",
-    "https://deno.land/x/mock_file@v1.1.2/mod.ts": "57b111ba84b5611c09ed82ef300dd063eb278ef68bd286d5149e5b018eb8948d",
-    "https://deno.land/x/mock_file@v1.1.2/src/memory_file.ts": "24817e782c819cdfb48b9459dc8ad568e8fb2cd2934cd5b775688147e6dc4cbd",
-    "https://deno.land/x/mock_file@v1.1.2/src/polyfill.ts": "f10f05ec2493cb1e029b30cd211a21803b7683d811813d519696aa2939529b35",
-    "https://deno.land/x/ts_morph@18.0.0/bootstrap/mod.ts": "b53aad517f106c4079971fcd4a81ab79fadc40b50061a3ab2b741a09119d51e9",
-    "https://deno.land/x/ts_morph@18.0.0/bootstrap/ts_morph_bootstrap.js": "6645ac03c5e6687dfa8c78109dc5df0250b811ecb3aea2d97c504c35e8401c06",
-    "https://deno.land/x/ts_morph@18.0.0/common/DenoRuntime.ts": "6a7180f0c6e90dcf23ccffc86aa8271c20b1c4f34c570588d08a45880b7e172d",
-    "https://deno.land/x/ts_morph@18.0.0/common/mod.ts": "01985d2ee7da8d1caee318a9d07664774fbee4e31602bc2bb6bb62c3489555ed",
-    "https://deno.land/x/ts_morph@18.0.0/common/ts_morph_common.js": "845671ca951073400ce142f8acefa2d39ea9a51e29ca80928642f3f8cf2b7700",
-    "https://deno.land/x/ts_morph@18.0.0/common/typescript.js": "d5c598b6a2db2202d0428fca5fd79fc9a301a71880831a805d778797d2413c59",
-    "https://esm.sh/ansi-escapes@6.2.0": "508d1d1d8f44b52c45e9c701cd5a78c56d7764a14d005d5328f0cff72b0291b4",
+    "https://esm.sh/ansi-escapes@6.2.0": "9cd33a5845aed0e739ee1ca89bead377a01e5eefee017e1cef38d244c2d4357a",
     "https://esm.sh/v124/*acorn-loose@8.4.0": "5255c5344625c52612c421cb99b66d401af8772342a5de8bac38d1d78d0f94b4",
     "https://esm.sh/v124/*log-update@5.0.1": "49199324effae77a660f21ea75937847315fdb5f67a86881496717314bb95b2a",
     "https://esm.sh/v124/@aws-crypto/crc32@3.0.0/denonext/crc32.mjs": "28103a74b87c49846c0f2851adc7d6ca8f8d677f079819cd786d8f9b0af5e08e",
@@ -896,17 +629,13 @@
     "https://esm.sh/v124/ajv@8.11.0/denonext/dist/vocabularies/validation/required.js": "945988a3e33e21322f240fa5304a3dbbb4a80b2cf8c56032bfd27df9294c9793",
     "https://esm.sh/v124/ajv@8.11.0/denonext/dist/vocabularies/validation/uniqueItems.js": "77bf5a6f1bdd56129e0a217865e9d2beb2fd6623a6b288cc4b5af93c49cad69b",
     "https://esm.sh/v124/ajv@8.11.0/dist/2019.js": "646df403ae1a0d94045d530fe3b7ca65e4bd4a1163e6041d34bc9d321bb7334f",
-    "https://esm.sh/v124/ajv@8.11.0/dist/core": "7af19c4e1b07edc97c97d9a4e1b2859154d626fc9d10b618c8fda3b178ce26c0",
     "https://esm.sh/v124/ajv@8.12.0": "7621f26ca63271c26d3c0d3812be6a826809bb56036db0bf3ffb3e82bb7482d1",
     "https://esm.sh/v124/ajv@8.12.0/denonext/ajv.mjs": "dd2ce45ec01492d9d6bf91bc6bf0e2608fc8977d70cc4bbc0d2d7c1453d514b9",
     "https://esm.sh/v124/ansi-regex@6.0.1/denonext/ansi-regex.mjs": "9b72c27d642eff10be605f8b170084bdf8a9729e1fd525aad5139977fc80dc59",
     "https://esm.sh/v124/ansi-styles@6.2.1/denonext/ansi-styles.mjs": "d40ccc0e5be3eced4c723f48dbdb5249efa00b7f8561a90999b7487db3ee5c09",
     "https://esm.sh/v124/async@3.2.4/denonext/forEach.js": "c265bae8dbe1a8b9bbc26bf012f89f0c37fbb5864df1232af585596f13896ace",
     "https://esm.sh/v124/async@3.2.4/denonext/series.js": "a555746f7a024becc7b63f37ed3cf00aaa32302855e0c07cdfc0b3aa9abee3c2",
-    "https://esm.sh/v124/base64-js@1.5.1/denonext/base64-js.mjs": "fc961905a7e7a9a1c753f006903a610306d299569a0b3af9c48318a28ac48b84",
     "https://esm.sh/v124/bowser@2.11.0/denonext/bowser.mjs": "9876a6f4cb94547829dc82a448b1b7a02b590a819aeb0a29f7e6416fca3a446a",
-    "https://esm.sh/v124/buffer@4.9.2": "97db8c9b70e6b09f4a09440a62cb9a8a577c1a28787ece11dcaaed918d790840",
-    "https://esm.sh/v124/buffer@4.9.2/denonext/buffer.mjs": "b41fd0012d60aea2ec448dddefa54c90b4d9dd2a3a1bdb224679c8861a9cb28f",
     "https://esm.sh/v124/chownr@2.0.0/denonext/chownr.mjs": "230f6e23902418045f5057ff9a7cee6a7a28a21655eeb98f5671395d32839a1a",
     "https://esm.sh/v124/cli-cursor@4.0.0": "2ed1740a92df113d48f30ac950b174042c2f904556219b3165f04d4e50392cac",
     "https://esm.sh/v124/cli-cursor@4.0.0/denonext/cli-cursor.mjs": "0904486398e7456058b337418d8af5338924f07682b96f1b3016a01b94009ecc",
@@ -919,8 +648,6 @@
     "https://esm.sh/v124/estraverse@5.3.0": "a172212d2f4a87f930430cb7e0462cb507891b9f390e17025533f572d895092c",
     "https://esm.sh/v124/estraverse@5.3.0/denonext/estraverse.mjs": "3e3574b932e1b7c1476f467e6103559d7b978df412e50b6b97299679d4556004",
     "https://esm.sh/v124/esutils@2.0.3/denonext/esutils.mjs": "56b9038ae71de0a374c86435a347793030afc96deb151466a5009cb5384a85d0",
-    "https://esm.sh/v124/events@1.1.1": "aa42c257bbfdbd6e635628110bc65ef7d66d7110ffcdcdf894e3afc722e0c87b",
-    "https://esm.sh/v124/events@1.1.1/denonext/events.mjs": "cafdffd6a39d45b8282efe4b29a0b902ce76e3fd426840fb54eb3e6cec208fab",
     "https://esm.sh/v124/fast-deep-equal@3.1.3/denonext/fast-deep-equal.mjs": "6313b3e05436550e1c0aeb2a282206b9b8d9213b4c6f247964dd7bb4835fb9e5",
     "https://esm.sh/v124/fast-xml-parser@4.2.5/denonext/fast-xml-parser.mjs": "0132711d650c1ba44721b4bcf6e0636cd0e0f81894694e8e5b36242434eceb9c",
     "https://esm.sh/v124/fecha@4.2.3/denonext/fecha.mjs": "d87efb3f6dd068229dcaaf6ce19072720634695668c49da74e6d7289fc67ee48",
@@ -928,16 +655,12 @@
     "https://esm.sh/v124/fs-minipass@2.1.0/denonext/fs-minipass.mjs": "e3ee6d0df9871f490d05b070b47cd6495f8f33ae4eed90167242cd9819c82cca",
     "https://esm.sh/v124/hcl2-json-parser@1.0.1": "c50574c485772ae59ed44a3b8f679b85e6ff61788b76f9849e3da1065c249823",
     "https://esm.sh/v124/hcl2-json-parser@1.0.1/denonext/hcl2-json-parser.mjs": "a51581a1181c31284bfb1ff0907f79a34b248e3fcb1b333c986b8273781fb39f",
-    "https://esm.sh/v124/ieee754@1.2.1/denonext/ieee754.mjs": "9ec2806065f50afcd4cf3f3f2f38d93e777a92a5954dda00d219f57d4b24832f",
     "https://esm.sh/v124/inherits@2.0.4/denonext/inherits.mjs": "8095f3d6aea060c904fb24ae50f2882779c0acbe5d56814514c8b5153f3b4b3b",
     "https://esm.sh/v124/is-fullwidth-code-point@4.0.0/denonext/is-fullwidth-code-point.mjs": "e9801323732e385027651be9a815a58a6f340484316c9f6ed27a0eec6c48c161",
     "https://esm.sh/v124/is-stream@2.0.1/denonext/is-stream.mjs": "456bc690361378c52fac24a7f362044f036942b1298e812799a67882d6c1febf",
-    "https://esm.sh/v124/isarray@1.0.0/denonext/isarray.mjs": "6368a41cf02c83843453ac571deb4c393c14e6f5e1d9ca6bbe43a4623f3856c8",
     "https://esm.sh/v124/isexe@2.0.0/denonext/isexe.mjs": "733c6d04662ec8e40a169a321fcdfaaafb5fce27a3113408c09f17becbd1acd8",
     "https://esm.sh/v124/js-yaml@4.1.0": "546cd3718747e8cc7d431a079df570c6c62417b338387f6e0a059b4c102d3847",
     "https://esm.sh/v124/js-yaml@4.1.0/denonext/js-yaml.mjs": "b4e4f1b1cadcc873d4079f242cdc811b1a36fdd0eb01b9b54ca2ae6e2ff2a92f",
-    "https://esm.sh/v124/json-schema-to-markdown@1.1.1": "5aca501b5a208417028043d2872def0276ec94880b874f4054aaf4a2da0a828f",
-    "https://esm.sh/v124/json-schema-to-markdown@1.1.1/denonext/json-schema-to-markdown.mjs": "7432381ab482eb331d311d86a7cba1c19db5310e67e1ccf59aa4b13068318e4f",
     "https://esm.sh/v124/json-schema-traverse@1.0.0/denonext/json-schema-traverse.mjs": "c5da8353bc014e49ebbb1a2c0162d29969a14c325da19644e511f96ba670cc45",
     "https://esm.sh/v124/log-update@5.0.1/X-ZS8q/denonext/log-update.mjs": "fb4b88d17be9478cfcd97d14aa971028ec5f6681ecaf32b6f7790bb242f15125",
     "https://esm.sh/v124/logform@2.5.1/denonext/json.js": "c7f923ba5d3c3144bcf8bd0a0ab71ffb69a3bc458f05f179ddeef1b456aaa8bb",
@@ -951,8 +674,6 @@
     "https://esm.sh/v124/ms@2.1.3/denonext/ms.mjs": "0f06597e493998793b8f52232868976128fca326eec3bcd56f10e66e6efd1839",
     "https://esm.sh/v124/one-time@1.0.0/denonext/one-time.mjs": "b3a4b3d5de194c6f2bf7a9556607a622f9ac27b08a35ac6e87d9f9e7580afcc4",
     "https://esm.sh/v124/onetime@5.1.2/denonext/onetime.mjs": "dcdb53bfa68b0d43d301c1fd4bb131150a6e58ba843db9b61e6dcd282c9434da",
-    "https://esm.sh/v124/querystring@0.2.0": "c426159c0d0a6c8732e9e3e976230edb77cb7b225ae7f5b4fc1c131563bf9537",
-    "https://esm.sh/v124/querystring@0.2.0/denonext/querystring.mjs": "0cc5ad58cddf88b56ccd9bbb47ecdb8707f037c9a25ad47cf38a7fdc4189ae1b",
     "https://esm.sh/v124/readable-stream@3.6.2/denonext/lib/_stream_writable.js": "fcd380d7da84d0708692263c1e46b1a673d7ab64da9f654b73abfad0219a7560",
     "https://esm.sh/v124/readable-stream@3.6.2/denonext/readable-stream.mjs": "061037c060d88267d4cbbd57688f0bf2ed6cceda918e17d407f83248a6aad672",
     "https://esm.sh/v124/restore-cursor@4.0.0/denonext/restore-cursor.mjs": "9c2be16e5018dcfeed7503897c1113d9427016b1b907013ee36cb1aa27173fb9",
@@ -979,8 +700,6 @@
     "https://esm.sh/v124/unique-names-generator@4.7.1": "6d61270c703d91c6fb27bd9b68a06f241659c3f01df03f76f4e8b540acf45c44",
     "https://esm.sh/v124/unique-names-generator@4.7.1/denonext/unique-names-generator.mjs": "b40a40ff6a8533a2f35c6a4b6883a5e5737d75287f2d635a863176247bcb7f19",
     "https://esm.sh/v124/uri-js@4.4.1/denonext/uri-js.mjs": "4b46d46cd678979debedbf2d05fa39b50ec17656e3960a9ec3418e7763aa7c34",
-    "https://esm.sh/v124/url@0.10.3": "07386e574238e0e64451b25c1d699146b6bace90f58e1e751dae337d003fe44c",
-    "https://esm.sh/v124/url@0.10.3/denonext/url.mjs": "ba58c05c534164ab58a98e7e9f9ba67400750a2d71031658c4580d7112ac4144",
     "https://esm.sh/v124/util-deprecate@1.0.2/denonext/util-deprecate.mjs": "e7f4e3a1ec5eb3f2e04dbfaf90e4874f535ca298a7c91512f1d083e1ba765c37",
     "https://esm.sh/v124/uuid@8.3.2/denonext/uuid.mjs": "c0da38266b24ac79d62b02290f17caba7e75d078f6771bbe8fb61bdef60f837c",
     "https://esm.sh/v124/which@3.0.1": "f27ee01cac772029a95d37fad83158ebe6a6cc4222ee9396f5f54bfe4903da6c",
@@ -992,6 +711,6 @@
     "https://esm.sh/v124/wrap-ansi@8.1.0": "da576a84619b45bf324bfb582b74f3c38b23deb5abb204d3b3aca329f6cd970d",
     "https://esm.sh/v124/wrap-ansi@8.1.0/denonext/wrap-ansi.mjs": "1804d60795c6034323e4b8dc92425aa9ab28385b87bb700772e16cb92bb0d8f8",
     "https://esm.sh/v124/yallist@4.0.0/denonext/yallist.mjs": "61f180d807dda50bac17028eda05d5722a3fecef6e98a9064e2353ea6864fd82",
-    "https://esm.sh/v129/ansi-escapes@6.2.0/denonext/ansi-escapes.mjs": "e82f350a4e3ef3113cd99b6d99513de1821bb9ae50bb4ed1dbbd6b9789af560d"
+    "https://esm.sh/v133/ansi-escapes@6.2.0/denonext/ansi-escapes.mjs": "e82f350a4e3ef3113cd99b6d99513de1821bb9ae50bb4ed1dbbd6b9789af560d"
   }
 }

--- a/src/commands/build/datacenter.ts
+++ b/src/commands/build/datacenter.ts
@@ -41,7 +41,10 @@ async function build_action(options: BuildOptions, context_file: string): Promis
   }
 
   datacenter = await datacenter.build(async (build_options) => {
-    const build_dir = path.join(context, build_options.context);
+    // An absolute path is set as build_options.context when building from a git repo.
+    const build_dir = path.isAbsolute(build_options.context)
+      ? build_options.context
+      : path.join(context, build_options.context);
     console.log(`Building module: ${build_dir}`);
     const server = new ModuleServer(build_options.plugin);
     const client = await server.start(build_dir);

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -1,12 +1,14 @@
 import { BaseCommand } from '../base-command.ts';
 import ComponentBuildCommand from './component.ts';
 import DatacenterBuildCommand from './datacenter.ts';
+import ModuleBuildCommand from './module.ts';
 
 const BuildCommands = BaseCommand()
   .name('build')
-  .description('Build a Component or Datacenter into an OCI image');
+  .description('Build a Component, Datacenter, or Module into an OCI image');
 
 BuildCommands.command('component', ComponentBuildCommand.alias('components').alias('comp'));
 BuildCommands.command('datacenter', DatacenterBuildCommand.alias('datacenters').alias('dcs').alias('dc'));
+BuildCommands.command('module', ModuleBuildCommand.alias('modules').alias('mod').alias('mods'));
 
 export default BuildCommands;

--- a/src/commands/build/module.ts
+++ b/src/commands/build/module.ts
@@ -1,0 +1,77 @@
+import { isAbsolute } from 'https://deno.land/std@0.50.0/path/posix.ts';
+import * as path from 'std/path/mod.ts';
+import { ModuleServer } from '../../datacenter-modules/server.ts';
+import { isPlugin, PluginArray } from '../../datacenter-modules/types.ts';
+import { verifyDocker } from '../../docker/helper.ts';
+import { ImageRepository } from '../../oci/index.ts';
+import { exec } from '../../utils/command.ts';
+import { BaseCommand, GlobalOptions } from '../base-command.ts';
+import { module_push_action } from '../push/module.ts';
+
+type BuildOptions = {
+  tag?: string[];
+  name?: string;
+  platform?: string;
+  plugin: string;
+  push: boolean;
+  verbose: boolean;
+} & GlobalOptions;
+
+const ModuleBuildCommand = BaseCommand()
+  .description('Build a module for use within a datacenter')
+  .arguments('<context:string>') // 'Path to the module to build'
+  .option('-n, --name <module_name:string>', 'Name of this module image')
+  .option('-p, --plugin <plugin:string>', 'Plugin this module is built with', { default: 'pulumi' })
+  .option('-t, --tag <tag:string>', 'Tags to assign to the built module image', { collect: true })
+  .option('--platform <platform:string>', 'Target platform for the build')
+  .option('--push [push:boolean]', 'Push the tagged images after buliding', { default: false })
+  .option('-v, --verbose [verbose:boolean]', 'Turn on verbose logs', { default: false })
+  .action(build_action);
+
+async function build_action(options: BuildOptions, context_file: string): Promise<void> {
+  verifyDocker();
+  if (!isPlugin(options.plugin)) {
+    console.log(`Invalid value for plugin: ${options.plugin}. Valid plugin values: ${PluginArray.join(', ')}`);
+    Deno.exit(1);
+  }
+
+  if (options.push && (!options.tag || options.tag.length <= 0)) {
+    console.error('Cannot use --push flag without at least one --tag');
+    Deno.exit(1);
+  }
+
+  const context_relative = !Deno.lstatSync(context_file).isFile ? context_file : path.dirname(context_file);
+  const context = isAbsolute(context_relative) ? context_relative : path.join(Deno.cwd(), context_relative);
+  // Default module name to being the folder name of the module
+  const module_name = options.name || context.split(path.SEP).at(-1) || 'module';
+
+  console.log(`Building module ${module_name} at: ${context}`);
+
+  const server = new ModuleServer(options.plugin);
+  const client = await server.start(context);
+  let image;
+  try {
+    const build = await client.build({ directory: context, platform: options.platform });
+    client.close();
+    await server.stop();
+    image = build.image;
+  } catch (e) {
+    client.close();
+    await server.stop();
+    throw new Error(e);
+  }
+
+  if (options.tag) {
+    for (const tag of options.tag) {
+      const imageRepository = new ImageRepository(`${module_name}:${tag}`);
+      await exec('docker', { args: ['tag', image, imageRepository.toString()] });
+      console.log(`Module Tagged: ${imageRepository.toString()}`);
+
+      if (options.push) {
+        module_push_action({ verbose: options.verbose }, imageRepository.toString());
+      }
+    }
+  }
+}
+
+export default ModuleBuildCommand;

--- a/src/commands/common/datacenter.ts
+++ b/src/commands/common/datacenter.ts
@@ -148,7 +148,11 @@ export class DatacenterUtils {
 
   public async buildDatacenter(datacenter: Datacenter, context: string, logger?: Logger): Promise<Datacenter> {
     return datacenter.build(async (build_options) => {
-      let module_path = path.join(path.dirname(context), build_options.context);
+      // An absolute path is set as build_options.context when building from a git repo.
+      let module_path = path.isAbsolute(build_options.context)
+        ? build_options.context
+        : path.join(path.dirname(context), build_options.context);
+
       if (!path.isAbsolute(path.dirname(context))) {
         module_path = path.resolve(module_path);
       }

--- a/src/commands/push/index.ts
+++ b/src/commands/push/index.ts
@@ -1,6 +1,7 @@
 import { BaseCommand } from '../base-command.ts';
 import ComponentPushCommand from './component.ts';
 import DatacenterPushCommand from './datacenter.ts';
+import ModulePushCommand from './module.ts';
 
 const PushCommands = BaseCommand()
   .name('push')
@@ -8,5 +9,6 @@ const PushCommands = BaseCommand()
 
 PushCommands.command('component', ComponentPushCommand.alias('components').alias('comp'));
 PushCommands.command('datacenter', DatacenterPushCommand.alias('datacenters').alias('dcs').alias('dc'));
+PushCommands.command('module', ModulePushCommand.alias('modules').alias('mod').alias('mods'));
 
 export default PushCommands;

--- a/src/commands/push/module.ts
+++ b/src/commands/push/module.ts
@@ -1,0 +1,35 @@
+import { verifyDocker } from '../../docker/helper.ts';
+import { exec, execVerbose } from '../../utils/command.ts';
+import { BaseCommand, GlobalOptions } from '../base-command.ts';
+
+type BuildOptions = {
+  verbose: boolean;
+} & GlobalOptions;
+
+const ModulePushCommand = BaseCommand()
+  .description('Push a module up to the registry')
+  .arguments('<tagged_image:string>')
+  .option('-v, --verbose [verbose:boolean]', 'Turn on verbose logs', { default: false })
+  .action(module_push_action);
+
+export async function module_push_action(options: BuildOptions, tagged_image: string): Promise<void> {
+  verifyDocker();
+
+  if (options.verbose) {
+    const { code } = await execVerbose('docker', { args: ['push', tagged_image] });
+    if (code != 0) {
+      Deno.exit(code);
+    }
+  } else {
+    const { code, stderr } = await exec('docker', { args: ['push', tagged_image] });
+
+    if (stderr && stderr.length > 0) {
+      console.error(stderr);
+      Deno.exit(code);
+    }
+  }
+
+  console.log(`Pushed image: ${tagged_image}`);
+}
+
+export default ModulePushCommand;

--- a/src/components/component-schema.ts
+++ b/src/components/component-schema.ts
@@ -1,3851 +1,3897 @@
 export default {
-  "oneOf": [
+  'oneOf': [
     {
-      "additionalProperties": false,
-      "properties": {
-        "databases": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "description": {
-                "description": "A human-readable description of the database and its purpose",
-                "type": "string"
+      'additionalProperties': false,
+      'properties': {
+        'databases': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'description': {
+                'description': 'A human-readable description of the database and its purpose',
+                'type': 'string',
               },
-              "type": {
-                "description": "Type of database and version required by the application",
-                "type": "string"
-              }
+              'type': {
+                'description': 'Type of database and version required by the application',
+                'type': 'string',
+              },
             },
-            "required": [
-              "type"
+            'required': [
+              'type',
             ],
-            "type": "object"
+            'type': 'object',
           },
-          "description": "A set of databases required by the component",
-          "type": "object"
+          'description': 'A set of databases required by the component',
+          'type': 'object',
         },
-        "dependencies": {
-          "additionalProperties": {
-            "anyOf": [
+        'dependencies': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "type": "string"
+                'type': 'string',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "component": {
-                    "type": "string"
+                'additionalProperties': false,
+                'properties': {
+                  'component': {
+                    'type': 'string',
                   },
-                  "inputs": {
-                    "additionalProperties": {
-                      "items": {
-                        "type": "string"
+                  'inputs': {
+                    'additionalProperties': {
+                      'items': {
+                        'type': 'string',
                       },
-                      "type": "array"
+                      'type': 'array',
                     },
-                    "type": "object"
-                  }
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "component"
+                'required': [
+                  'component',
                 ],
-                "type": "object"
-              }
-            ]
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A set of components and associated versions that this component depends on.",
-          "type": "object"
+          'description': 'A set of components and associated versions that this component depends on.',
+          'type': 'object',
         },
-        "description": {
-          "description": "A human-readable description of the component and what it should be used for",
-          "type": "string"
+        'description': {
+          'description': 'A human-readable description of the component and what it should be used for',
+          'type': 'string',
         },
-        "interfaces": {
-          "additionalProperties": {
-            "anyOf": [
+        'interfaces': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "type": "string"
+                'type': 'string',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "description": {
-                    "description": "A human-readable description of the interface and how it should be used.",
-                    "type": "string"
+                'additionalProperties': false,
+                'properties': {
+                  'description': {
+                    'description': 'A human-readable description of the interface and how it should be used.',
+                    'type': 'string',
                   },
-                  "ingress": {
-                    "additionalProperties": false,
-                    "description": "Ingress configuration to allow the interface to be exposed publicly",
-                    "properties": {
-                      "internal": {
-                        "default": false,
-                        "description": "Indicates whether the ingress rule should be attached to a public or private load balancer",
-                        "type": "boolean"
+                  'ingress': {
+                    'additionalProperties': false,
+                    'description': 'Ingress configuration to allow the interface to be exposed publicly',
+                    'properties': {
+                      'internal': {
+                        'default': false,
+                        'description':
+                          'Indicates whether the ingress rule should be attached to a public or private load balancer',
+                        'type': 'boolean',
                       },
-                      "path": {
-                        "description": "Path that the interface should be exposed under",
-                        "type": "string"
+                      'path': {
+                        'description': 'Path that the interface should be exposed under',
+                        'type': 'string',
                       },
-                      "subdomain": {
-                        "description": "Subdomain the interface should be accessed on",
-                        "type": "string"
-                      }
+                      'subdomain': {
+                        'description': 'Subdomain the interface should be accessed on',
+                        'type': 'string',
+                      },
                     },
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "url": {
-                    "description": "The url of the downstream interfaces that should be exposed. This will usually be a reference to one of your services interfaces.",
-                    "type": "string"
-                  }
+                  'url': {
+                    'description':
+                      'The url of the downstream interfaces that should be exposed. This will usually be a reference to one of your services interfaces.',
+                    'type': 'string',
+                  },
                 },
-                "required": [
-                  "url"
+                'required': [
+                  'url',
                 ],
-                "type": "object"
-              }
-            ]
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A dictionary of named interfaces that the component makes available to upstreams, including other components via dependencies or environments via interface mapping.\n\nInterfaces can either be an object describing the interface, or a string shorthand that directly applies to the `url` value.",
-          "type": "object"
+          'description':
+            'A dictionary of named interfaces that the component makes available to upstreams, including other components via dependencies or environments via interface mapping.\n\nInterfaces can either be an object describing the interface, or a string shorthand that directly applies to the `url` value.',
+          'type': 'object',
         },
-        "keywords": {
-          "description": "An array of keywords that can be used to index the component and make it discoverable for others",
-          "items": {
-            "type": "string"
+        'keywords': {
+          'description':
+            'An array of keywords that can be used to index the component and make it discoverable for others',
+          'items': {
+            'type': 'string',
           },
-          "type": "array"
+          'type': 'array',
         },
-        "name": {
-          "description": "Unique name of the component. Must be of the format, <account-name>/<component-name>",
-          "type": "string"
+        'name': {
+          'description': 'Unique name of the component. Must be of the format, <account-name>/<component-name>',
+          'type': 'string',
         },
-        "parameters": {
-          "additionalProperties": {
-            "anyOf": [
+        'parameters': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "type": "string"
+                'type': 'string',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "default": {
-                    "description": "The default value to apply to the parameter when one wasn't provided by the operator",
-                    "type": [
-                      "string",
-                      "number"
-                    ]
+                'additionalProperties': false,
+                'properties': {
+                  'default': {
+                    'description':
+                      'The default value to apply to the parameter when one wasn\'t provided by the operator',
+                    'type': [
+                      'string',
+                      'number',
+                    ],
                   },
-                  "description": {
-                    "description": "A human-readable description of the parameter, how it should be used, and what kinds of values it supports.",
-                    "type": "string"
+                  'description': {
+                    'description':
+                      'A human-readable description of the parameter, how it should be used, and what kinds of values it supports.',
+                    'type': 'string',
                   },
-                  "merge": {
-                    "default": false,
-                    "description": "Whether or not to merge results from multiple sources into a single array",
-                    "type": "boolean"
+                  'merge': {
+                    'default': false,
+                    'description': 'Whether or not to merge results from multiple sources into a single array',
+                    'type': 'boolean',
                   },
-                  "required": {
-                    "default": false,
-                    "description": "A boolean indicating whether or not an operator is required ot provide a value",
-                    "type": "boolean"
-                  }
+                  'required': {
+                    'default': false,
+                    'description': 'A boolean indicating whether or not an operator is required ot provide a value',
+                    'type': 'boolean',
+                  },
                 },
-                "type": "object"
-              }
-            ]
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A dictionary of named parameters that this component uses to configure services.\n\nParameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.\n\nThis is an alias for the `inputs` field.",
-          "type": "object"
+          'description':
+            'A dictionary of named parameters that this component uses to configure services.\n\nParameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.\n\nThis is an alias for the `inputs` field.',
+          'type': 'object',
         },
-        "secrets": {
-          "additionalProperties": {
-            "anyOf": [
+        'secrets': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "type": "string"
+                'type': 'string',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "default": {
-                    "description": "The default value to apply to the parameter when one wasn't provided by the operator",
-                    "type": [
-                      "string",
-                      "number"
-                    ]
+                'additionalProperties': false,
+                'properties': {
+                  'default': {
+                    'description':
+                      'The default value to apply to the parameter when one wasn\'t provided by the operator',
+                    'type': [
+                      'string',
+                      'number',
+                    ],
                   },
-                  "description": {
-                    "description": "A human-readable description of the parameter, how it should be used, and what kinds of values it supports.",
-                    "type": "string"
+                  'description': {
+                    'description':
+                      'A human-readable description of the parameter, how it should be used, and what kinds of values it supports.',
+                    'type': 'string',
                   },
-                  "merge": {
-                    "default": false,
-                    "description": "Whether or not to merge results from multiple sources into a single array",
-                    "type": "boolean"
+                  'merge': {
+                    'default': false,
+                    'description': 'Whether or not to merge results from multiple sources into a single array',
+                    'type': 'boolean',
                   },
-                  "required": {
-                    "default": false,
-                    "description": "A boolean indicating whether or not an operator is required ot provide a value",
-                    "type": "boolean"
-                  }
+                  'required': {
+                    'default': false,
+                    'description': 'A boolean indicating whether or not an operator is required ot provide a value',
+                    'type': 'boolean',
+                  },
                 },
-                "type": "object"
-              }
-            ]
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A dictionary of named parameters that this component uses to configure services.\n\nParameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.\n\nThis is an alias for the `inputs` field.",
-          "type": "object"
+          'description':
+            'A dictionary of named parameters that this component uses to configure services.\n\nParameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.\n\nThis is an alias for the `inputs` field.',
+          'type': 'object',
         },
-        "services": {
-          "additionalProperties": {
-            "anyOf": [
+        'services': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "additionalProperties": false,
-                "properties": {
-                  "command": {
-                    "anyOf": [
+                'additionalProperties': false,
+                'properties': {
+                  'command': {
+                    'anyOf': [
                       {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "cpu": {
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "debug": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "build": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "args": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "type": "object"
-                          },
-                          "context": {
-                            "type": "string"
-                          },
-                          "dockerfile": {
-                            "type": "string"
-                          },
-                          "target": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "cpu": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "depends_on": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "entrypoint": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number"
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "image": {
-                        "type": "string"
-                      },
-                      "interfaces": {
-                        "additionalProperties": {
-                          "anyOf": [
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "host": {
-                                  "type": "string"
-                                },
-                                "ingress": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "internal": {
-                                      "type": "boolean"
-                                    },
-                                    "path": {
-                                      "type": "string"
-                                    },
-                                    "subdomain": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "password": {
-                                  "type": "string"
-                                },
-                                "port": {
-                                  "type": [
-                                    "number",
-                                    "string"
-                                  ]
-                                },
-                                "protocol": {
-                                  "type": "string"
-                                },
-                                "url": {
-                                  "type": "string"
-                                },
-                                "username": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "labels": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "language": {
-                        "type": "string"
-                      },
-                      "liveness_probe": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "command": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ]
-                          },
-                          "failure_threshold": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "initial_delay": {
-                            "type": "string"
-                          },
-                          "interval": {
-                            "type": "string"
-                          },
-                          "path": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "success_threshold": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "timeout": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "memory": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": "string"
-                      },
-                      "replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "scaling": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "max_replicas": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "metrics": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "cpu": {
-                                "type": [
-                                  "number",
-                                  "string"
-                                ]
-                              },
-                              "memory": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "min_replicas": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "volumes": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "host_path": {
-                              "type": "string"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "mount_path": {
-                              "type": "string"
-                            },
-                            "readonly": {
-                              "type": [
-                                "boolean",
-                                "string"
-                              ]
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "depends_on": {
-                    "description": "Specify other services that you want to wait for before starting this one",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "entrypoint": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
-                    ]
+                        'type': 'array',
+                      },
+                    ],
                   },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number"
-                      ]
-                    },
-                    "type": "object"
+                  'cpu': {
+                    'type': [
+                      'number',
+                      'string',
+                    ],
                   },
-                  "image": {
-                    "type": "string"
-                  },
-                  "interfaces": {
-                    "additionalProperties": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "host": {
-                              "type": "string"
+                  'debug': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'build': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'args': {
+                            'additionalProperties': {
+                              'type': 'string',
                             },
-                            "ingress": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "internal": {
-                                  "type": "boolean"
-                                },
-                                "path": {
-                                  "type": "string"
-                                },
-                                "subdomain": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "password": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "type": [
-                                "number",
-                                "string"
-                              ]
-                            },
-                            "protocol": {
-                              "type": "string"
-                            },
-                            "url": {
-                              "type": "string"
-                            },
-                            "username": {
-                              "type": "string"
-                            }
+                            'type': 'object',
                           },
-                          "required": [
-                            "port"
-                          ],
-                          "type": "object"
-                        }
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "type": "object"
-                  },
-                  "language": {
-                    "deprecated": true,
-                    "type": "string"
-                  },
-                  "liveness_probe": {
-                    "additionalProperties": false,
-                    "description": "Task run continuously to determine if each service replica is healthy",
-                    "properties": {
-                      "command": {
-                        "anyOf": [
+                          'context': {
+                            'type': 'string',
+                          },
+                          'dockerfile': {
+                            'type': 'string',
+                          },
+                          'target': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'command': {
+                        'anyOf': [
                           {
-                            "type": "string"
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
                           },
                           {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
+                            'type': 'string',
+                          },
                         ],
-                        "description": "Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set)."
                       },
-                      "failure_threshold": {
-                        "default": 3,
-                        "description": "The number of times to retry a failed health check before the container is considered unhealthy",
-                        "type": [
-                          "number",
-                          "string"
-                        ]
+                      'cpu': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
                       },
-                      "initial_delay": {
-                        "default": "0s",
-                        "description": "Delays the check from running for the specified amount of time",
-                        "type": "string"
+                      'depends_on': {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
                       },
-                      "interval": {
-                        "default": "30s",
-                        "description": "The time period in seconds between each health check execution. You may specify any value between: 5s and 300s",
-                        "type": "string"
-                      },
-                      "path": {
-                        "deprecated": true,
-                        "type": "string"
-                      },
-                      "port": {
-                        "deprecated": true,
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "success_threshold": {
-                        "default": 1,
-                        "description": "The number of times to retry a health check before the container is considered healthy",
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "timeout": {
-                        "default": "5s",
-                        "description": "The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between 2s and 60s.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "memory": {
-                    "type": "string"
-                  },
-                  "platform": {
-                    "type": "string"
-                  },
-                  "replicas": {
-                    "description": "Number of replicas of the deployment to run",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "scaling": {
-                    "additionalProperties": false,
-                    "description": "Autoscaling rules for the deployment",
-                    "properties": {
-                      "max_replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "metrics": {
-                        "additionalProperties": false,
-                        "description": "Metrics to be used to trigger autoscaling",
-                        "properties": {
-                          "cpu": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
+                      'entrypoint': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
                           },
-                          "memory": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
+                          {
+                            'type': 'string',
+                          },
+                        ],
                       },
-                      "min_replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      }
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'image': {
+                        'type': 'string',
+                      },
+                      'interfaces': {
+                        'additionalProperties': {
+                          'anyOf': [
+                            {
+                              'additionalProperties': false,
+                              'properties': {
+                                'host': {
+                                  'type': 'string',
+                                },
+                                'ingress': {
+                                  'additionalProperties': false,
+                                  'properties': {
+                                    'internal': {
+                                      'type': 'boolean',
+                                    },
+                                    'path': {
+                                      'type': 'string',
+                                    },
+                                    'subdomain': {
+                                      'type': 'string',
+                                    },
+                                  },
+                                  'type': 'object',
+                                },
+                                'password': {
+                                  'type': 'string',
+                                },
+                                'port': {
+                                  'type': [
+                                    'number',
+                                    'string',
+                                  ],
+                                },
+                                'protocol': {
+                                  'type': 'string',
+                                },
+                                'url': {
+                                  'type': 'string',
+                                },
+                                'username': {
+                                  'type': 'string',
+                                },
+                              },
+                              'type': 'object',
+                            },
+                            {
+                              'type': 'number',
+                            },
+                            {
+                              'type': 'string',
+                            },
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'labels': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'language': {
+                        'type': 'string',
+                      },
+                      'liveness_probe': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'command': {
+                            'anyOf': [
+                              {
+                                'items': {
+                                  'type': 'string',
+                                },
+                                'type': 'array',
+                              },
+                              {
+                                'type': 'string',
+                              },
+                            ],
+                          },
+                          'failure_threshold': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'initial_delay': {
+                            'type': 'string',
+                          },
+                          'interval': {
+                            'type': 'string',
+                          },
+                          'path': {
+                            'type': 'string',
+                          },
+                          'port': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'success_threshold': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'timeout': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'memory': {
+                        'type': 'string',
+                      },
+                      'platform': {
+                        'type': 'string',
+                      },
+                      'replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'scaling': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'max_replicas': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'metrics': {
+                            'additionalProperties': false,
+                            'properties': {
+                              'cpu': {
+                                'type': [
+                                  'number',
+                                  'string',
+                                ],
+                              },
+                              'memory': {
+                                'type': 'string',
+                              },
+                            },
+                            'type': 'object',
+                          },
+                          'min_replicas': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'volumes': {
+                        'additionalProperties': {
+                          'additionalProperties': false,
+                          'properties': {
+                            'description': {
+                              'type': 'string',
+                            },
+                            'host_path': {
+                              'type': 'string',
+                            },
+                            'image': {
+                              'type': 'string',
+                            },
+                            'mount_path': {
+                              'type': 'string',
+                            },
+                            'readonly': {
+                              'type': [
+                                'boolean',
+                                'string',
+                              ],
+                            },
+                          },
+                          'type': 'object',
+                        },
+                        'type': 'object',
+                      },
                     },
-                    "required": [
-                      "min_replicas",
-                      "max_replicas",
-                      "metrics"
-                    ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "host_path": {
-                          "type": "string"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "type": "string"
-                        },
-                        "readonly": {
-                          "type": [
-                            "boolean",
-                            "string"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "mount_path"
-                      ],
-                      "type": "object"
+                  'depends_on': {
+                    'description': 'Specify other services that you want to wait for before starting this one',
+                    'items': {
+                      'type': 'string',
                     },
-                    "type": "object"
-                  }
+                    'type': 'array',
+                  },
+                  'entrypoint': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'image': {
+                    'type': 'string',
+                  },
+                  'interfaces': {
+                    'additionalProperties': {
+                      'anyOf': [
+                        {
+                          'type': 'number',
+                        },
+                        {
+                          'type': 'string',
+                        },
+                        {
+                          'additionalProperties': false,
+                          'properties': {
+                            'host': {
+                              'type': 'string',
+                            },
+                            'ingress': {
+                              'additionalProperties': false,
+                              'properties': {
+                                'internal': {
+                                  'type': 'boolean',
+                                },
+                                'path': {
+                                  'type': 'string',
+                                },
+                                'subdomain': {
+                                  'type': 'string',
+                                },
+                              },
+                              'type': 'object',
+                            },
+                            'password': {
+                              'type': 'string',
+                            },
+                            'port': {
+                              'type': [
+                                'number',
+                                'string',
+                              ],
+                            },
+                            'protocol': {
+                              'type': 'string',
+                            },
+                            'url': {
+                              'type': 'string',
+                            },
+                            'username': {
+                              'type': 'string',
+                            },
+                          },
+                          'required': [
+                            'port',
+                          ],
+                          'type': 'object',
+                        },
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'type': 'object',
+                  },
+                  'language': {
+                    'deprecated': true,
+                    'type': 'string',
+                  },
+                  'liveness_probe': {
+                    'additionalProperties': false,
+                    'description': 'Task run continuously to determine if each service replica is healthy',
+                    'properties': {
+                      'command': {
+                        'anyOf': [
+                          {
+                            'type': 'string',
+                          },
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                        ],
+                        'description':
+                          'Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set).',
+                      },
+                      'failure_threshold': {
+                        'default': 3,
+                        'description':
+                          'The number of times to retry a failed health check before the container is considered unhealthy',
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'initial_delay': {
+                        'default': '0s',
+                        'description': 'Delays the check from running for the specified amount of time',
+                        'type': 'string',
+                      },
+                      'interval': {
+                        'default': '30s',
+                        'description':
+                          'The time period in seconds between each health check execution. You may specify any value between: 5s and 300s',
+                        'type': 'string',
+                      },
+                      'path': {
+                        'deprecated': true,
+                        'type': 'string',
+                      },
+                      'port': {
+                        'deprecated': true,
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'success_threshold': {
+                        'default': 1,
+                        'description':
+                          'The number of times to retry a health check before the container is considered healthy',
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'timeout': {
+                        'default': '5s',
+                        'description':
+                          'The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between 2s and 60s.',
+                        'type': 'string',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'memory': {
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'type': 'string',
+                  },
+                  'replicas': {
+                    'description': 'Number of replicas of the deployment to run',
+                    'type': [
+                      'number',
+                      'string',
+                    ],
+                  },
+                  'scaling': {
+                    'additionalProperties': false,
+                    'description': 'Autoscaling rules for the deployment',
+                    'properties': {
+                      'max_replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'metrics': {
+                        'additionalProperties': false,
+                        'description': 'Metrics to be used to trigger autoscaling',
+                        'properties': {
+                          'cpu': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'memory': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'min_replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                    },
+                    'required': [
+                      'min_replicas',
+                      'max_replicas',
+                      'metrics',
+                    ],
+                    'type': 'object',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'description': {
+                          'type': 'string',
+                        },
+                        'host_path': {
+                          'type': 'string',
+                        },
+                        'image': {
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'type': 'string',
+                        },
+                        'readonly': {
+                          'type': [
+                            'boolean',
+                            'string',
+                          ],
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "image"
+                'required': [
+                  'image',
                 ],
-                "type": "object"
+                'type': 'object',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "build": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "additionalProperties": {
-                          "type": "string"
+                'additionalProperties': false,
+                'properties': {
+                  'build': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'args': {
+                        'additionalProperties': {
+                          'type': 'string',
                         },
-                        "type": "object"
+                        'type': 'object',
                       },
-                      "context": {
-                        "type": "string"
+                      'context': {
+                        'type': 'string',
                       },
-                      "dockerfile": {
-                        "type": "string"
+                      'dockerfile': {
+                        'type': 'string',
                       },
-                      "target": {
-                        "type": "string"
-                      }
+                      'target': {
+                        'type': 'string',
+                      },
                     },
-                    "required": [
-                      "context"
+                    'required': [
+                      'context',
                     ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "command": {
-                    "anyOf": [
+                  'command': {
+                    'anyOf': [
                       {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "cpu": {
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "debug": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "build": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "args": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "type": "object"
-                          },
-                          "context": {
-                            "type": "string"
-                          },
-                          "dockerfile": {
-                            "type": "string"
-                          },
-                          "target": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "cpu": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "depends_on": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "entrypoint": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number"
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "image": {
-                        "type": "string"
-                      },
-                      "interfaces": {
-                        "additionalProperties": {
-                          "anyOf": [
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "host": {
-                                  "type": "string"
-                                },
-                                "ingress": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "internal": {
-                                      "type": "boolean"
-                                    },
-                                    "path": {
-                                      "type": "string"
-                                    },
-                                    "subdomain": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "password": {
-                                  "type": "string"
-                                },
-                                "port": {
-                                  "type": [
-                                    "number",
-                                    "string"
-                                  ]
-                                },
-                                "protocol": {
-                                  "type": "string"
-                                },
-                                "url": {
-                                  "type": "string"
-                                },
-                                "username": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "labels": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "language": {
-                        "type": "string"
-                      },
-                      "liveness_probe": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "command": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ]
-                          },
-                          "failure_threshold": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "initial_delay": {
-                            "type": "string"
-                          },
-                          "interval": {
-                            "type": "string"
-                          },
-                          "path": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "success_threshold": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "timeout": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "memory": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": "string"
-                      },
-                      "replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "scaling": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "max_replicas": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "metrics": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "cpu": {
-                                "type": [
-                                  "number",
-                                  "string"
-                                ]
-                              },
-                              "memory": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "min_replicas": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "volumes": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "host_path": {
-                              "type": "string"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "mount_path": {
-                              "type": "string"
-                            },
-                            "readonly": {
-                              "type": [
-                                "boolean",
-                                "string"
-                              ]
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "depends_on": {
-                    "description": "Specify other services that you want to wait for before starting this one",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "entrypoint": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
-                    ]
+                        'type': 'array',
+                      },
+                    ],
                   },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number"
-                      ]
-                    },
-                    "type": "object"
+                  'cpu': {
+                    'type': [
+                      'number',
+                      'string',
+                    ],
                   },
-                  "interfaces": {
-                    "additionalProperties": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "host": {
-                              "type": "string"
+                  'debug': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'build': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'args': {
+                            'additionalProperties': {
+                              'type': 'string',
                             },
-                            "ingress": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "internal": {
-                                  "type": "boolean"
-                                },
-                                "path": {
-                                  "type": "string"
-                                },
-                                "subdomain": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "password": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "type": [
-                                "number",
-                                "string"
-                              ]
-                            },
-                            "protocol": {
-                              "type": "string"
-                            },
-                            "url": {
-                              "type": "string"
-                            },
-                            "username": {
-                              "type": "string"
-                            }
+                            'type': 'object',
                           },
-                          "required": [
-                            "port"
-                          ],
-                          "type": "object"
-                        }
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "type": "object"
-                  },
-                  "language": {
-                    "deprecated": true,
-                    "type": "string"
-                  },
-                  "liveness_probe": {
-                    "additionalProperties": false,
-                    "description": "Task run continuously to determine if each service replica is healthy",
-                    "properties": {
-                      "command": {
-                        "anyOf": [
+                          'context': {
+                            'type': 'string',
+                          },
+                          'dockerfile': {
+                            'type': 'string',
+                          },
+                          'target': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'command': {
+                        'anyOf': [
                           {
-                            "type": "string"
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
                           },
                           {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
+                            'type': 'string',
+                          },
                         ],
-                        "description": "Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set)."
                       },
-                      "failure_threshold": {
-                        "default": 3,
-                        "description": "The number of times to retry a failed health check before the container is considered unhealthy",
-                        "type": [
-                          "number",
-                          "string"
-                        ]
+                      'cpu': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
                       },
-                      "initial_delay": {
-                        "default": "0s",
-                        "description": "Delays the check from running for the specified amount of time",
-                        "type": "string"
+                      'depends_on': {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
                       },
-                      "interval": {
-                        "default": "30s",
-                        "description": "The time period in seconds between each health check execution. You may specify any value between: 5s and 300s",
-                        "type": "string"
-                      },
-                      "path": {
-                        "deprecated": true,
-                        "type": "string"
-                      },
-                      "port": {
-                        "deprecated": true,
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "success_threshold": {
-                        "default": 1,
-                        "description": "The number of times to retry a health check before the container is considered healthy",
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "timeout": {
-                        "default": "5s",
-                        "description": "The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between 2s and 60s.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "memory": {
-                    "type": "string"
-                  },
-                  "platform": {
-                    "type": "string"
-                  },
-                  "replicas": {
-                    "description": "Number of replicas of the deployment to run",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "scaling": {
-                    "additionalProperties": false,
-                    "description": "Autoscaling rules for the deployment",
-                    "properties": {
-                      "max_replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "metrics": {
-                        "additionalProperties": false,
-                        "description": "Metrics to be used to trigger autoscaling",
-                        "properties": {
-                          "cpu": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
+                      'entrypoint': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
                           },
-                          "memory": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
+                          {
+                            'type': 'string',
+                          },
+                        ],
                       },
-                      "min_replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      }
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'image': {
+                        'type': 'string',
+                      },
+                      'interfaces': {
+                        'additionalProperties': {
+                          'anyOf': [
+                            {
+                              'additionalProperties': false,
+                              'properties': {
+                                'host': {
+                                  'type': 'string',
+                                },
+                                'ingress': {
+                                  'additionalProperties': false,
+                                  'properties': {
+                                    'internal': {
+                                      'type': 'boolean',
+                                    },
+                                    'path': {
+                                      'type': 'string',
+                                    },
+                                    'subdomain': {
+                                      'type': 'string',
+                                    },
+                                  },
+                                  'type': 'object',
+                                },
+                                'password': {
+                                  'type': 'string',
+                                },
+                                'port': {
+                                  'type': [
+                                    'number',
+                                    'string',
+                                  ],
+                                },
+                                'protocol': {
+                                  'type': 'string',
+                                },
+                                'url': {
+                                  'type': 'string',
+                                },
+                                'username': {
+                                  'type': 'string',
+                                },
+                              },
+                              'type': 'object',
+                            },
+                            {
+                              'type': 'number',
+                            },
+                            {
+                              'type': 'string',
+                            },
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'labels': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'language': {
+                        'type': 'string',
+                      },
+                      'liveness_probe': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'command': {
+                            'anyOf': [
+                              {
+                                'items': {
+                                  'type': 'string',
+                                },
+                                'type': 'array',
+                              },
+                              {
+                                'type': 'string',
+                              },
+                            ],
+                          },
+                          'failure_threshold': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'initial_delay': {
+                            'type': 'string',
+                          },
+                          'interval': {
+                            'type': 'string',
+                          },
+                          'path': {
+                            'type': 'string',
+                          },
+                          'port': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'success_threshold': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'timeout': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'memory': {
+                        'type': 'string',
+                      },
+                      'platform': {
+                        'type': 'string',
+                      },
+                      'replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'scaling': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'max_replicas': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'metrics': {
+                            'additionalProperties': false,
+                            'properties': {
+                              'cpu': {
+                                'type': [
+                                  'number',
+                                  'string',
+                                ],
+                              },
+                              'memory': {
+                                'type': 'string',
+                              },
+                            },
+                            'type': 'object',
+                          },
+                          'min_replicas': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'volumes': {
+                        'additionalProperties': {
+                          'additionalProperties': false,
+                          'properties': {
+                            'description': {
+                              'type': 'string',
+                            },
+                            'host_path': {
+                              'type': 'string',
+                            },
+                            'image': {
+                              'type': 'string',
+                            },
+                            'mount_path': {
+                              'type': 'string',
+                            },
+                            'readonly': {
+                              'type': [
+                                'boolean',
+                                'string',
+                              ],
+                            },
+                          },
+                          'type': 'object',
+                        },
+                        'type': 'object',
+                      },
                     },
-                    "required": [
-                      "min_replicas",
-                      "max_replicas",
-                      "metrics"
-                    ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "host_path": {
-                          "type": "string"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "type": "string"
-                        },
-                        "readonly": {
-                          "type": [
-                            "boolean",
-                            "string"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "mount_path"
-                      ],
-                      "type": "object"
+                  'depends_on': {
+                    'description': 'Specify other services that you want to wait for before starting this one',
+                    'items': {
+                      'type': 'string',
                     },
-                    "type": "object"
-                  }
+                    'type': 'array',
+                  },
+                  'entrypoint': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'interfaces': {
+                    'additionalProperties': {
+                      'anyOf': [
+                        {
+                          'type': 'number',
+                        },
+                        {
+                          'type': 'string',
+                        },
+                        {
+                          'additionalProperties': false,
+                          'properties': {
+                            'host': {
+                              'type': 'string',
+                            },
+                            'ingress': {
+                              'additionalProperties': false,
+                              'properties': {
+                                'internal': {
+                                  'type': 'boolean',
+                                },
+                                'path': {
+                                  'type': 'string',
+                                },
+                                'subdomain': {
+                                  'type': 'string',
+                                },
+                              },
+                              'type': 'object',
+                            },
+                            'password': {
+                              'type': 'string',
+                            },
+                            'port': {
+                              'type': [
+                                'number',
+                                'string',
+                              ],
+                            },
+                            'protocol': {
+                              'type': 'string',
+                            },
+                            'url': {
+                              'type': 'string',
+                            },
+                            'username': {
+                              'type': 'string',
+                            },
+                          },
+                          'required': [
+                            'port',
+                          ],
+                          'type': 'object',
+                        },
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'type': 'object',
+                  },
+                  'language': {
+                    'deprecated': true,
+                    'type': 'string',
+                  },
+                  'liveness_probe': {
+                    'additionalProperties': false,
+                    'description': 'Task run continuously to determine if each service replica is healthy',
+                    'properties': {
+                      'command': {
+                        'anyOf': [
+                          {
+                            'type': 'string',
+                          },
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                        ],
+                        'description':
+                          'Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set).',
+                      },
+                      'failure_threshold': {
+                        'default': 3,
+                        'description':
+                          'The number of times to retry a failed health check before the container is considered unhealthy',
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'initial_delay': {
+                        'default': '0s',
+                        'description': 'Delays the check from running for the specified amount of time',
+                        'type': 'string',
+                      },
+                      'interval': {
+                        'default': '30s',
+                        'description':
+                          'The time period in seconds between each health check execution. You may specify any value between: 5s and 300s',
+                        'type': 'string',
+                      },
+                      'path': {
+                        'deprecated': true,
+                        'type': 'string',
+                      },
+                      'port': {
+                        'deprecated': true,
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'success_threshold': {
+                        'default': 1,
+                        'description':
+                          'The number of times to retry a health check before the container is considered healthy',
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'timeout': {
+                        'default': '5s',
+                        'description':
+                          'The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between 2s and 60s.',
+                        'type': 'string',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'memory': {
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'type': 'string',
+                  },
+                  'replicas': {
+                    'description': 'Number of replicas of the deployment to run',
+                    'type': [
+                      'number',
+                      'string',
+                    ],
+                  },
+                  'scaling': {
+                    'additionalProperties': false,
+                    'description': 'Autoscaling rules for the deployment',
+                    'properties': {
+                      'max_replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'metrics': {
+                        'additionalProperties': false,
+                        'description': 'Metrics to be used to trigger autoscaling',
+                        'properties': {
+                          'cpu': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'memory': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'min_replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                    },
+                    'required': [
+                      'min_replicas',
+                      'max_replicas',
+                      'metrics',
+                    ],
+                    'type': 'object',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'description': {
+                          'type': 'string',
+                        },
+                        'host_path': {
+                          'type': 'string',
+                        },
+                        'image': {
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'type': 'string',
+                        },
+                        'readonly': {
+                          'type': [
+                            'boolean',
+                            'string',
+                          ],
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "build"
+                'required': [
+                  'build',
                 ],
-                "type": "object"
+                'type': 'object',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "build": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "additionalProperties": {
-                          "type": "string"
+                'additionalProperties': false,
+                'properties': {
+                  'build': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'args': {
+                        'additionalProperties': {
+                          'type': 'string',
                         },
-                        "type": "object"
+                        'type': 'object',
                       },
-                      "context": {
-                        "type": "string"
+                      'context': {
+                        'type': 'string',
                       },
-                      "dockerfile": {
-                        "type": "string"
+                      'dockerfile': {
+                        'type': 'string',
                       },
-                      "target": {
-                        "type": "string"
-                      }
+                      'target': {
+                        'type': 'string',
+                      },
                     },
-                    "required": [
-                      "context"
+                    'required': [
+                      'context',
                     ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "command": {
-                    "anyOf": [
+                  'command': {
+                    'anyOf': [
                       {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "cpu": {
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "debug": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "build": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "args": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "type": "object"
-                          },
-                          "context": {
-                            "type": "string"
-                          },
-                          "dockerfile": {
-                            "type": "string"
-                          },
-                          "target": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "cpu": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "depends_on": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "entrypoint": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number"
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "image": {
-                        "type": "string"
-                      },
-                      "interfaces": {
-                        "additionalProperties": {
-                          "anyOf": [
-                            {
-                              "additionalProperties": false,
-                              "properties": {
-                                "host": {
-                                  "type": "string"
-                                },
-                                "ingress": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "internal": {
-                                      "type": "boolean"
-                                    },
-                                    "path": {
-                                      "type": "string"
-                                    },
-                                    "subdomain": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "type": "object"
-                                },
-                                "password": {
-                                  "type": "string"
-                                },
-                                "port": {
-                                  "type": [
-                                    "number",
-                                    "string"
-                                  ]
-                                },
-                                "protocol": {
-                                  "type": "string"
-                                },
-                                "url": {
-                                  "type": "string"
-                                },
-                                "username": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            {
-                              "type": "number"
-                            },
-                            {
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "labels": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "language": {
-                        "type": "string"
-                      },
-                      "liveness_probe": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "command": {
-                            "anyOf": [
-                              {
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ]
-                          },
-                          "failure_threshold": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "initial_delay": {
-                            "type": "string"
-                          },
-                          "interval": {
-                            "type": "string"
-                          },
-                          "path": {
-                            "type": "string"
-                          },
-                          "port": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "success_threshold": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "timeout": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "memory": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": "string"
-                      },
-                      "replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "scaling": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "max_replicas": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          },
-                          "metrics": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "cpu": {
-                                "type": [
-                                  "number",
-                                  "string"
-                                ]
-                              },
-                              "memory": {
-                                "type": "string"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "min_replicas": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "volumes": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "host_path": {
-                              "type": "string"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "mount_path": {
-                              "type": "string"
-                            },
-                            "readonly": {
-                              "type": [
-                                "boolean",
-                                "string"
-                              ]
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "depends_on": {
-                    "description": "Specify other services that you want to wait for before starting this one",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "entrypoint": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
-                    ]
+                        'type': 'array',
+                      },
+                    ],
                   },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number"
-                      ]
-                    },
-                    "type": "object"
+                  'cpu': {
+                    'type': [
+                      'number',
+                      'string',
+                    ],
                   },
-                  "image": {
-                    "type": "string"
-                  },
-                  "interfaces": {
-                    "additionalProperties": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "host": {
-                              "type": "string"
+                  'debug': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'build': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'args': {
+                            'additionalProperties': {
+                              'type': 'string',
                             },
-                            "ingress": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "internal": {
-                                  "type": "boolean"
-                                },
-                                "path": {
-                                  "type": "string"
-                                },
-                                "subdomain": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object"
-                            },
-                            "password": {
-                              "type": "string"
-                            },
-                            "port": {
-                              "type": [
-                                "number",
-                                "string"
-                              ]
-                            },
-                            "protocol": {
-                              "type": "string"
-                            },
-                            "url": {
-                              "type": "string"
-                            },
-                            "username": {
-                              "type": "string"
-                            }
+                            'type': 'object',
                           },
-                          "required": [
-                            "port"
-                          ],
-                          "type": "object"
-                        }
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "type": "object"
-                  },
-                  "language": {
-                    "deprecated": true,
-                    "type": "string"
-                  },
-                  "liveness_probe": {
-                    "additionalProperties": false,
-                    "description": "Task run continuously to determine if each service replica is healthy",
-                    "properties": {
-                      "command": {
-                        "anyOf": [
+                          'context': {
+                            'type': 'string',
+                          },
+                          'dockerfile': {
+                            'type': 'string',
+                          },
+                          'target': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'command': {
+                        'anyOf': [
                           {
-                            "type": "string"
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
                           },
                           {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
+                            'type': 'string',
+                          },
                         ],
-                        "description": "Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set)."
                       },
-                      "failure_threshold": {
-                        "default": 3,
-                        "description": "The number of times to retry a failed health check before the container is considered unhealthy",
-                        "type": [
-                          "number",
-                          "string"
-                        ]
+                      'cpu': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
                       },
-                      "initial_delay": {
-                        "default": "0s",
-                        "description": "Delays the check from running for the specified amount of time",
-                        "type": "string"
+                      'depends_on': {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
                       },
-                      "interval": {
-                        "default": "30s",
-                        "description": "The time period in seconds between each health check execution. You may specify any value between: 5s and 300s",
-                        "type": "string"
-                      },
-                      "path": {
-                        "deprecated": true,
-                        "type": "string"
-                      },
-                      "port": {
-                        "deprecated": true,
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "success_threshold": {
-                        "default": 1,
-                        "description": "The number of times to retry a health check before the container is considered healthy",
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "timeout": {
-                        "default": "5s",
-                        "description": "The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between 2s and 60s.",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "memory": {
-                    "type": "string"
-                  },
-                  "platform": {
-                    "type": "string"
-                  },
-                  "replicas": {
-                    "description": "Number of replicas of the deployment to run",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "scaling": {
-                    "additionalProperties": false,
-                    "description": "Autoscaling rules for the deployment",
-                    "properties": {
-                      "max_replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "metrics": {
-                        "additionalProperties": false,
-                        "description": "Metrics to be used to trigger autoscaling",
-                        "properties": {
-                          "cpu": {
-                            "type": [
-                              "number",
-                              "string"
-                            ]
+                      'entrypoint': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
                           },
-                          "memory": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
+                          {
+                            'type': 'string',
+                          },
+                        ],
                       },
-                      "min_replicas": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      }
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'image': {
+                        'type': 'string',
+                      },
+                      'interfaces': {
+                        'additionalProperties': {
+                          'anyOf': [
+                            {
+                              'additionalProperties': false,
+                              'properties': {
+                                'host': {
+                                  'type': 'string',
+                                },
+                                'ingress': {
+                                  'additionalProperties': false,
+                                  'properties': {
+                                    'internal': {
+                                      'type': 'boolean',
+                                    },
+                                    'path': {
+                                      'type': 'string',
+                                    },
+                                    'subdomain': {
+                                      'type': 'string',
+                                    },
+                                  },
+                                  'type': 'object',
+                                },
+                                'password': {
+                                  'type': 'string',
+                                },
+                                'port': {
+                                  'type': [
+                                    'number',
+                                    'string',
+                                  ],
+                                },
+                                'protocol': {
+                                  'type': 'string',
+                                },
+                                'url': {
+                                  'type': 'string',
+                                },
+                                'username': {
+                                  'type': 'string',
+                                },
+                              },
+                              'type': 'object',
+                            },
+                            {
+                              'type': 'number',
+                            },
+                            {
+                              'type': 'string',
+                            },
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'labels': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'language': {
+                        'type': 'string',
+                      },
+                      'liveness_probe': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'command': {
+                            'anyOf': [
+                              {
+                                'items': {
+                                  'type': 'string',
+                                },
+                                'type': 'array',
+                              },
+                              {
+                                'type': 'string',
+                              },
+                            ],
+                          },
+                          'failure_threshold': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'initial_delay': {
+                            'type': 'string',
+                          },
+                          'interval': {
+                            'type': 'string',
+                          },
+                          'path': {
+                            'type': 'string',
+                          },
+                          'port': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'success_threshold': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'timeout': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'memory': {
+                        'type': 'string',
+                      },
+                      'platform': {
+                        'type': 'string',
+                      },
+                      'replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'scaling': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'max_replicas': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'metrics': {
+                            'additionalProperties': false,
+                            'properties': {
+                              'cpu': {
+                                'type': [
+                                  'number',
+                                  'string',
+                                ],
+                              },
+                              'memory': {
+                                'type': 'string',
+                              },
+                            },
+                            'type': 'object',
+                          },
+                          'min_replicas': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'volumes': {
+                        'additionalProperties': {
+                          'additionalProperties': false,
+                          'properties': {
+                            'description': {
+                              'type': 'string',
+                            },
+                            'host_path': {
+                              'type': 'string',
+                            },
+                            'image': {
+                              'type': 'string',
+                            },
+                            'mount_path': {
+                              'type': 'string',
+                            },
+                            'readonly': {
+                              'type': [
+                                'boolean',
+                                'string',
+                              ],
+                            },
+                          },
+                          'type': 'object',
+                        },
+                        'type': 'object',
+                      },
                     },
-                    "required": [
-                      "min_replicas",
-                      "max_replicas",
-                      "metrics"
-                    ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "host_path": {
-                          "type": "string"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "type": "string"
-                        },
-                        "readonly": {
-                          "type": [
-                            "boolean",
-                            "string"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "mount_path"
-                      ],
-                      "type": "object"
+                  'depends_on': {
+                    'description': 'Specify other services that you want to wait for before starting this one',
+                    'items': {
+                      'type': 'string',
                     },
-                    "type": "object"
-                  }
+                    'type': 'array',
+                  },
+                  'entrypoint': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'image': {
+                    'type': 'string',
+                  },
+                  'interfaces': {
+                    'additionalProperties': {
+                      'anyOf': [
+                        {
+                          'type': 'number',
+                        },
+                        {
+                          'type': 'string',
+                        },
+                        {
+                          'additionalProperties': false,
+                          'properties': {
+                            'host': {
+                              'type': 'string',
+                            },
+                            'ingress': {
+                              'additionalProperties': false,
+                              'properties': {
+                                'internal': {
+                                  'type': 'boolean',
+                                },
+                                'path': {
+                                  'type': 'string',
+                                },
+                                'subdomain': {
+                                  'type': 'string',
+                                },
+                              },
+                              'type': 'object',
+                            },
+                            'password': {
+                              'type': 'string',
+                            },
+                            'port': {
+                              'type': [
+                                'number',
+                                'string',
+                              ],
+                            },
+                            'protocol': {
+                              'type': 'string',
+                            },
+                            'url': {
+                              'type': 'string',
+                            },
+                            'username': {
+                              'type': 'string',
+                            },
+                          },
+                          'required': [
+                            'port',
+                          ],
+                          'type': 'object',
+                        },
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'type': 'object',
+                  },
+                  'language': {
+                    'deprecated': true,
+                    'type': 'string',
+                  },
+                  'liveness_probe': {
+                    'additionalProperties': false,
+                    'description': 'Task run continuously to determine if each service replica is healthy',
+                    'properties': {
+                      'command': {
+                        'anyOf': [
+                          {
+                            'type': 'string',
+                          },
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                        ],
+                        'description':
+                          'Command that runs the http check. This field is disjunctive with `path` and `port` (only one of `command` or `path`/`port` can be set).',
+                      },
+                      'failure_threshold': {
+                        'default': 3,
+                        'description':
+                          'The number of times to retry a failed health check before the container is considered unhealthy',
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'initial_delay': {
+                        'default': '0s',
+                        'description': 'Delays the check from running for the specified amount of time',
+                        'type': 'string',
+                      },
+                      'interval': {
+                        'default': '30s',
+                        'description':
+                          'The time period in seconds between each health check execution. You may specify any value between: 5s and 300s',
+                        'type': 'string',
+                      },
+                      'path': {
+                        'deprecated': true,
+                        'type': 'string',
+                      },
+                      'port': {
+                        'deprecated': true,
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'success_threshold': {
+                        'default': 1,
+                        'description':
+                          'The number of times to retry a health check before the container is considered healthy',
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'timeout': {
+                        'default': '5s',
+                        'description':
+                          'The time period to wait for a health check to succeed before it is considered a failure. You may specify any value between 2s and 60s.',
+                        'type': 'string',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'memory': {
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'type': 'string',
+                  },
+                  'replicas': {
+                    'description': 'Number of replicas of the deployment to run',
+                    'type': [
+                      'number',
+                      'string',
+                    ],
+                  },
+                  'scaling': {
+                    'additionalProperties': false,
+                    'description': 'Autoscaling rules for the deployment',
+                    'properties': {
+                      'max_replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'metrics': {
+                        'additionalProperties': false,
+                        'description': 'Metrics to be used to trigger autoscaling',
+                        'properties': {
+                          'cpu': {
+                            'type': [
+                              'number',
+                              'string',
+                            ],
+                          },
+                          'memory': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'min_replicas': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                    },
+                    'required': [
+                      'min_replicas',
+                      'max_replicas',
+                      'metrics',
+                    ],
+                    'type': 'object',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'description': {
+                          'type': 'string',
+                        },
+                        'host_path': {
+                          'type': 'string',
+                        },
+                        'image': {
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'type': 'string',
+                        },
+                        'readonly': {
+                          'type': [
+                            'boolean',
+                            'string',
+                          ],
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "build",
-                  "image"
+                'required': [
+                  'build',
+                  'image',
                 ],
-                "type": "object"
-              }
-            ]
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A set of named services that need to be run and persisted in order to power this component.",
-          "type": "object"
+          'description': 'A set of named services that need to be run and persisted in order to power this component.',
+          'type': 'object',
         },
-        "static": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "build": {
-                "additionalProperties": false,
-                "description": "Instructions on how to build the code into static files to be put into the `directory`. Builds will be done just-in-time (JIT) for deployments to ensure that environment variables are specific to the target environment.",
-                "properties": {
-                  "command": {
-                    "description": "Command to run to build the code",
-                    "type": "string"
+        'static': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'build': {
+                'additionalProperties': false,
+                'description':
+                  'Instructions on how to build the code into static files to be put into the `directory`. Builds will be done just-in-time (JIT) for deployments to ensure that environment variables are specific to the target environment.',
+                'properties': {
+                  'command': {
+                    'description': 'Command to run to build the code',
+                    'type': 'string',
                   },
-                  "context": {
-                    "description": "Folder to consider the context for the build relative to the component root",
-                    "type": "string"
+                  'context': {
+                    'description': 'Folder to consider the context for the build relative to the component root',
+                    'type': 'string',
                   },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number",
-                        "boolean"
-                      ]
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
+                        'boolean',
+                      ],
                     },
-                    "description": "Environment variables to inject into the build process",
-                    "type": "object"
-                  }
+                    'description': 'Environment variables to inject into the build process',
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "context",
-                  "command"
+                'required': [
+                  'context',
+                  'command',
                 ],
-                "type": "object"
+                'type': 'object',
               },
-              "debug": {
-                "additionalProperties": false,
-                "properties": {
-                  "build": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "command": {
-                        "type": "string"
+              'debug': {
+                'additionalProperties': false,
+                'properties': {
+                  'build': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'command': {
+                        'type': 'string',
                       },
-                      "context": {
-                        "type": "string"
+                      'context': {
+                        'type': 'string',
                       },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number",
-                            "boolean"
-                          ]
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                            'boolean',
+                          ],
                         },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "directory": {
-                    "type": "string"
-                  },
-                  "ingress": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "internal": {
-                        "type": "boolean"
+                        'type': 'object',
                       },
-                      "path": {
-                        "type": "string"
-                      },
-                      "subdomain": {
-                        "type": "string"
-                      }
                     },
-                    "type": "object"
-                  }
-                },
-                "type": "object"
-              },
-              "directory": {
-                "description": "Directory containing the static assets to be shipped to the bucket",
-                "type": "string"
-              },
-              "ingress": {
-                "additionalProperties": false,
-                "description": "Configure a DNS route to point to this static bucket",
-                "properties": {
-                  "internal": {
-                    "default": false,
-                    "description": "Whether or not this bucket should be exposed internally vs externally",
-                    "type": "boolean"
+                    'type': 'object',
                   },
-                  "path": {
-                    "description": "Sub-path to listen on when re-routing traffic from the ingress rule to the bucket",
-                    "type": "string"
+                  'directory': {
+                    'type': 'string',
                   },
-                  "subdomain": {
-                    "description": "Subdomain to use for the ingress rule",
-                    "type": "string"
-                  }
+                  'ingress': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'internal': {
+                        'type': 'boolean',
+                      },
+                      'path': {
+                        'type': 'string',
+                      },
+                      'subdomain': {
+                        'type': 'string',
+                      },
+                    },
+                    'type': 'object',
+                  },
                 },
-                "type": "object"
-              }
+                'type': 'object',
+              },
+              'directory': {
+                'description': 'Directory containing the static assets to be shipped to the bucket',
+                'type': 'string',
+              },
+              'ingress': {
+                'additionalProperties': false,
+                'description': 'Configure a DNS route to point to this static bucket',
+                'properties': {
+                  'internal': {
+                    'default': false,
+                    'description': 'Whether or not this bucket should be exposed internally vs externally',
+                    'type': 'boolean',
+                  },
+                  'path': {
+                    'description': 'Sub-path to listen on when re-routing traffic from the ingress rule to the bucket',
+                    'type': 'string',
+                  },
+                  'subdomain': {
+                    'description': 'Subdomain to use for the ingress rule',
+                    'type': 'string',
+                  },
+                },
+                'type': 'object',
+              },
             },
-            "required": [
-              "directory"
+            'required': [
+              'directory',
             ],
-            "type": "object"
+            'type': 'object',
           },
-          "description": "A set of static asset buckets to create and load with content.",
-          "type": "object"
+          'description': 'A set of static asset buckets to create and load with content.',
+          'type': 'object',
         },
-        "tasks": {
-          "additionalProperties": {
-            "anyOf": [
+        'tasks': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "additionalProperties": false,
-                "properties": {
-                  "command": {
-                    "anyOf": [
+                'additionalProperties': false,
+                'properties': {
+                  'command': {
+                    'anyOf': [
                       {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "cpu": {
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "debug": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "build": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "args": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "type": "object"
-                          },
-                          "context": {
-                            "type": "string"
-                          },
-                          "dockerfile": {
-                            "type": "string"
-                          },
-                          "target": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "cpu": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "entrypoint": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number"
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "image": {
-                        "type": "string"
-                      },
-                      "labels": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "language": {
-                        "type": "string"
-                      },
-                      "memory": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": "string"
-                      },
-                      "schedule": {
-                        "type": "string"
-                      },
-                      "volumes": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "host_path": {
-                              "type": "string"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "mount_path": {
-                              "type": "string"
-                            },
-                            "readonly": {
-                              "type": [
-                                "boolean",
-                                "string"
-                              ]
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "entrypoint": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number"
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "image": {
-                    "type": "string"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "type": "object"
-                  },
-                  "language": {
-                    "deprecated": true,
-                    "type": "string"
-                  },
-                  "memory": {
-                    "type": "string"
-                  },
-                  "platform": {
-                    "type": "string"
-                  },
-                  "schedule": {
-                    "type": "string"
-                  },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "host_path": {
-                          "type": "string"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "type": "string"
-                        },
-                        "readonly": {
-                          "type": [
-                            "boolean",
-                            "string"
-                          ]
-                        }
+                        'type': 'array',
                       },
-                      "required": [
-                        "mount_path"
-                      ],
-                      "type": "object"
-                    },
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "image"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "properties": {
-                  "build": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "context": {
-                        "type": "string"
-                      },
-                      "dockerfile": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "context"
                     ],
-                    "type": "object"
                   },
-                  "command": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "cpu": {
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "debug": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "build": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "args": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "type": "object"
-                          },
-                          "context": {
-                            "type": "string"
-                          },
-                          "dockerfile": {
-                            "type": "string"
-                          },
-                          "target": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "command": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "cpu": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "entrypoint": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number"
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "image": {
-                        "type": "string"
-                      },
-                      "labels": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "language": {
-                        "type": "string"
-                      },
-                      "memory": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": "string"
-                      },
-                      "schedule": {
-                        "type": "string"
-                      },
-                      "volumes": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "host_path": {
-                              "type": "string"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "mount_path": {
-                              "type": "string"
-                            },
-                            "readonly": {
-                              "type": [
-                                "boolean",
-                                "string"
-                              ]
-                            }
-                          },
-                          "type": "object"
-                        },
-                        "type": "object"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "entrypoint": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number"
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "type": "object"
-                  },
-                  "language": {
-                    "deprecated": true,
-                    "type": "string"
-                  },
-                  "memory": {
-                    "type": "string"
-                  },
-                  "platform": {
-                    "type": "string"
-                  },
-                  "schedule": {
-                    "type": "string"
-                  },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "host_path": {
-                          "type": "string"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "type": "string"
-                        },
-                        "readonly": {
-                          "type": [
-                            "boolean",
-                            "string"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "mount_path"
-                      ],
-                      "type": "object"
-                    },
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "build"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "properties": {
-                  "build": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "args": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "context": {
-                        "type": "string"
-                      },
-                      "dockerfile": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "context"
+                  'cpu': {
+                    'type': [
+                      'number',
+                      'string',
                     ],
-                    "type": "object"
                   },
-                  "command": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "cpu": {
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "debug": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "build": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "args": {
-                            "additionalProperties": {
-                              "type": "string"
+                  'debug': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'build': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'args': {
+                            'additionalProperties': {
+                              'type': 'string',
                             },
-                            "type": "object"
+                            'type': 'object',
                           },
-                          "context": {
-                            "type": "string"
+                          'context': {
+                            'type': 'string',
                           },
-                          "dockerfile": {
-                            "type": "string"
+                          'dockerfile': {
+                            'type': 'string',
                           },
-                          "target": {
-                            "type": "string"
-                          }
+                          'target': {
+                            'type': 'string',
+                          },
                         },
-                        "type": "object"
+                        'type': 'object',
                       },
-                      "command": {
-                        "anyOf": [
+                      'command': {
+                        'anyOf': [
                           {
-                            "items": {
-                              "type": "string"
+                            'items': {
+                              'type': 'string',
                             },
-                            "type": "array"
+                            'type': 'array',
                           },
                           {
-                            "type": "string"
-                          }
-                        ]
+                            'type': 'string',
+                          },
+                        ],
                       },
-                      "cpu": {
-                        "type": [
-                          "number",
-                          "string"
-                        ]
+                      'cpu': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
                       },
-                      "entrypoint": {
-                        "anyOf": [
+                      'entrypoint': {
+                        'anyOf': [
                           {
-                            "items": {
-                              "type": "string"
+                            'items': {
+                              'type': 'string',
                             },
-                            "type": "array"
+                            'type': 'array',
                           },
                           {
-                            "type": "string"
-                          }
-                        ]
-                      },
-                      "environment": {
-                        "additionalProperties": {
-                          "type": [
-                            "string",
-                            "number"
-                          ]
-                        },
-                        "type": "object"
-                      },
-                      "image": {
-                        "type": "string"
-                      },
-                      "labels": {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      "language": {
-                        "type": "string"
-                      },
-                      "memory": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": "string"
-                      },
-                      "schedule": {
-                        "type": "string"
-                      },
-                      "volumes": {
-                        "additionalProperties": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "host_path": {
-                              "type": "string"
-                            },
-                            "image": {
-                              "type": "string"
-                            },
-                            "mount_path": {
-                              "type": "string"
-                            },
-                            "readonly": {
-                              "type": [
-                                "boolean",
-                                "string"
-                              ]
-                            }
+                            'type': 'string',
                           },
-                          "type": "object"
+                        ],
+                      },
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                          ],
                         },
-                        "type": "object"
-                      }
+                        'type': 'object',
+                      },
+                      'image': {
+                        'type': 'string',
+                      },
+                      'labels': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'language': {
+                        'type': 'string',
+                      },
+                      'memory': {
+                        'type': 'string',
+                      },
+                      'platform': {
+                        'type': 'string',
+                      },
+                      'schedule': {
+                        'type': 'string',
+                      },
+                      'volumes': {
+                        'additionalProperties': {
+                          'additionalProperties': false,
+                          'properties': {
+                            'description': {
+                              'type': 'string',
+                            },
+                            'host_path': {
+                              'type': 'string',
+                            },
+                            'image': {
+                              'type': 'string',
+                            },
+                            'mount_path': {
+                              'type': 'string',
+                            },
+                            'readonly': {
+                              'type': [
+                                'boolean',
+                                'string',
+                              ],
+                            },
+                          },
+                          'type': 'object',
+                        },
+                        'type': 'object',
+                      },
                     },
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "entrypoint": {
-                    "anyOf": [
+                  'entrypoint': {
+                    'anyOf': [
                       {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
-                    ]
-                  },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "number"
-                      ]
-                    },
-                    "type": "object"
-                  },
-                  "image": {
-                    "type": "string"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "type": "object"
-                  },
-                  "language": {
-                    "deprecated": true,
-                    "type": "string"
-                  },
-                  "memory": {
-                    "type": "string"
-                  },
-                  "platform": {
-                    "type": "string"
-                  },
-                  "schedule": {
-                    "type": "string"
-                  },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "type": "string"
-                        },
-                        "host_path": {
-                          "type": "string"
-                        },
-                        "image": {
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "type": "string"
-                        },
-                        "readonly": {
-                          "type": [
-                            "boolean",
-                            "string"
-                          ]
-                        }
+                        'type': 'array',
                       },
-                      "required": [
-                        "mount_path"
+                    ],
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
                       ],
-                      "type": "object"
                     },
-                    "type": "object"
-                  }
+                    'type': 'object',
+                  },
+                  'image': {
+                    'type': 'string',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'type': 'object',
+                  },
+                  'language': {
+                    'deprecated': true,
+                    'type': 'string',
+                  },
+                  'memory': {
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'type': 'string',
+                  },
+                  'schedule': {
+                    'type': 'string',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'description': {
+                          'type': 'string',
+                        },
+                        'host_path': {
+                          'type': 'string',
+                        },
+                        'image': {
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'type': 'string',
+                        },
+                        'readonly': {
+                          'type': [
+                            'boolean',
+                            'string',
+                          ],
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "build",
-                  "image"
+                'required': [
+                  'image',
                 ],
-                "type": "object"
-              }
-            ]
-          },
-          "description": "A set of scheduled and triggerable tasks that get registered alongside the component. Tasks are great for data translation, reporting, and much more.",
-          "type": "object"
-        },
-        "variables": {
-          "additionalProperties": {
-            "anyOf": [
-              {
-                "type": "string"
+                'type': 'object',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "default": {
-                    "description": "The default value to apply to the parameter when one wasn't provided by the operator",
-                    "type": [
-                      "string",
-                      "number"
-                    ]
+                'additionalProperties': false,
+                'properties': {
+                  'build': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'args': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'context': {
+                        'type': 'string',
+                      },
+                      'dockerfile': {
+                        'type': 'string',
+                      },
+                      'target': {
+                        'type': 'string',
+                      },
+                    },
+                    'required': [
+                      'context',
+                    ],
+                    'type': 'object',
                   },
-                  "description": {
-                    "description": "A human-readable description of the parameter, how it should be used, and what kinds of values it supports.",
-                    "type": "string"
+                  'command': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
                   },
-                  "merge": {
-                    "default": false,
-                    "description": "Whether or not to merge results from multiple sources into a single array",
-                    "type": "boolean"
+                  'cpu': {
+                    'type': [
+                      'number',
+                      'string',
+                    ],
                   },
-                  "required": {
-                    "default": false,
-                    "description": "A boolean indicating whether or not an operator is required ot provide a value",
-                    "type": "boolean"
-                  }
+                  'debug': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'build': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'args': {
+                            'additionalProperties': {
+                              'type': 'string',
+                            },
+                            'type': 'object',
+                          },
+                          'context': {
+                            'type': 'string',
+                          },
+                          'dockerfile': {
+                            'type': 'string',
+                          },
+                          'target': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'command': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                          {
+                            'type': 'string',
+                          },
+                        ],
+                      },
+                      'cpu': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'entrypoint': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                          {
+                            'type': 'string',
+                          },
+                        ],
+                      },
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'image': {
+                        'type': 'string',
+                      },
+                      'labels': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'language': {
+                        'type': 'string',
+                      },
+                      'memory': {
+                        'type': 'string',
+                      },
+                      'platform': {
+                        'type': 'string',
+                      },
+                      'schedule': {
+                        'type': 'string',
+                      },
+                      'volumes': {
+                        'additionalProperties': {
+                          'additionalProperties': false,
+                          'properties': {
+                            'description': {
+                              'type': 'string',
+                            },
+                            'host_path': {
+                              'type': 'string',
+                            },
+                            'image': {
+                              'type': 'string',
+                            },
+                            'mount_path': {
+                              'type': 'string',
+                            },
+                            'readonly': {
+                              'type': [
+                                'boolean',
+                                'string',
+                              ],
+                            },
+                          },
+                          'type': 'object',
+                        },
+                        'type': 'object',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'entrypoint': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'type': 'object',
+                  },
+                  'language': {
+                    'deprecated': true,
+                    'type': 'string',
+                  },
+                  'memory': {
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'type': 'string',
+                  },
+                  'schedule': {
+                    'type': 'string',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'description': {
+                          'type': 'string',
+                        },
+                        'host_path': {
+                          'type': 'string',
+                        },
+                        'image': {
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'type': 'string',
+                        },
+                        'readonly': {
+                          'type': [
+                            'boolean',
+                            'string',
+                          ],
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'type': 'object',
+                  },
                 },
-                "type": "object"
-              }
-            ]
+                'required': [
+                  'build',
+                ],
+                'type': 'object',
+              },
+              {
+                'additionalProperties': false,
+                'properties': {
+                  'build': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'args': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'context': {
+                        'type': 'string',
+                      },
+                      'dockerfile': {
+                        'type': 'string',
+                      },
+                      'target': {
+                        'type': 'string',
+                      },
+                    },
+                    'required': [
+                      'context',
+                    ],
+                    'type': 'object',
+                  },
+                  'command': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                  },
+                  'cpu': {
+                    'type': [
+                      'number',
+                      'string',
+                    ],
+                  },
+                  'debug': {
+                    'additionalProperties': false,
+                    'properties': {
+                      'build': {
+                        'additionalProperties': false,
+                        'properties': {
+                          'args': {
+                            'additionalProperties': {
+                              'type': 'string',
+                            },
+                            'type': 'object',
+                          },
+                          'context': {
+                            'type': 'string',
+                          },
+                          'dockerfile': {
+                            'type': 'string',
+                          },
+                          'target': {
+                            'type': 'string',
+                          },
+                        },
+                        'type': 'object',
+                      },
+                      'command': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                          {
+                            'type': 'string',
+                          },
+                        ],
+                      },
+                      'cpu': {
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'entrypoint': {
+                        'anyOf': [
+                          {
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                          {
+                            'type': 'string',
+                          },
+                        ],
+                      },
+                      'environment': {
+                        'additionalProperties': {
+                          'type': [
+                            'string',
+                            'number',
+                          ],
+                        },
+                        'type': 'object',
+                      },
+                      'image': {
+                        'type': 'string',
+                      },
+                      'labels': {
+                        'additionalProperties': {
+                          'type': 'string',
+                        },
+                        'type': 'object',
+                      },
+                      'language': {
+                        'type': 'string',
+                      },
+                      'memory': {
+                        'type': 'string',
+                      },
+                      'platform': {
+                        'type': 'string',
+                      },
+                      'schedule': {
+                        'type': 'string',
+                      },
+                      'volumes': {
+                        'additionalProperties': {
+                          'additionalProperties': false,
+                          'properties': {
+                            'description': {
+                              'type': 'string',
+                            },
+                            'host_path': {
+                              'type': 'string',
+                            },
+                            'image': {
+                              'type': 'string',
+                            },
+                            'mount_path': {
+                              'type': 'string',
+                            },
+                            'readonly': {
+                              'type': [
+                                'boolean',
+                                'string',
+                              ],
+                            },
+                          },
+                          'type': 'object',
+                        },
+                        'type': 'object',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'entrypoint': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': [
+                        'string',
+                        'number',
+                      ],
+                    },
+                    'type': 'object',
+                  },
+                  'image': {
+                    'type': 'string',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'type': 'object',
+                  },
+                  'language': {
+                    'deprecated': true,
+                    'type': 'string',
+                  },
+                  'memory': {
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'type': 'string',
+                  },
+                  'schedule': {
+                    'type': 'string',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'description': {
+                          'type': 'string',
+                        },
+                        'host_path': {
+                          'type': 'string',
+                        },
+                        'image': {
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'type': 'string',
+                        },
+                        'readonly': {
+                          'type': [
+                            'boolean',
+                            'string',
+                          ],
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'type': 'object',
+                  },
+                },
+                'required': [
+                  'build',
+                  'image',
+                ],
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A dictionary of named parameters that this component uses to configure services.\n\nParameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.\n\nThis is an alias for the `parameters` field.",
-          "type": "object"
+          'description':
+            'A set of scheduled and triggerable tasks that get registered alongside the component. Tasks are great for data translation, reporting, and much more.',
+          'type': 'object',
         },
-        "version": {
-          "const": "v1",
-          "type": "string"
-        }
+        'variables': {
+          'additionalProperties': {
+            'anyOf': [
+              {
+                'type': 'string',
+              },
+              {
+                'additionalProperties': false,
+                'properties': {
+                  'default': {
+                    'description':
+                      'The default value to apply to the parameter when one wasn\'t provided by the operator',
+                    'type': [
+                      'string',
+                      'number',
+                    ],
+                  },
+                  'description': {
+                    'description':
+                      'A human-readable description of the parameter, how it should be used, and what kinds of values it supports.',
+                    'type': 'string',
+                  },
+                  'merge': {
+                    'default': false,
+                    'description': 'Whether or not to merge results from multiple sources into a single array',
+                    'type': 'boolean',
+                  },
+                  'required': {
+                    'default': false,
+                    'description': 'A boolean indicating whether or not an operator is required ot provide a value',
+                    'type': 'boolean',
+                  },
+                },
+                'type': 'object',
+              },
+            ],
+          },
+          'description':
+            'A dictionary of named parameters that this component uses to configure services.\n\nParameters can either be an object describing the parameter or a string shorthand that directly applies to the `default` value.\n\nThis is an alias for the `parameters` field.',
+          'type': 'object',
+        },
+        'version': {
+          'const': 'v1',
+          'type': 'string',
+        },
       },
-      "required": [
-        "version"
+      'required': [
+        'version',
       ],
-      "type": "object"
+      'type': 'object',
     },
     {
-      "additionalProperties": false,
-      "properties": {
-        "builds": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "args": {
-                "additionalProperties": {
-                  "type": "string"
+      'additionalProperties': false,
+      'properties': {
+        'builds': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'args': {
+                'additionalProperties': {
+                  'type': 'string',
                 },
-                "description": "A set of arguments to pass to the build job",
-                "examples": [
+                'description': 'A set of arguments to pass to the build job',
+                'examples': [
                   {
-                    "BUILDKIT_INLINE_CACHE": "1"
-                  }
+                    'BUILDKIT_INLINE_CACHE': '1',
+                  },
                 ],
-                "type": "object"
+                'type': 'object',
               },
-              "context": {
-                "description": "Path to the folder containing the code to build",
-                "examples": [
-                  "./"
+              'context': {
+                'description': 'Path to the folder containing the code to build',
+                'examples': [
+                  './',
                 ],
-                "type": "string"
+                'type': 'string',
               },
-              "debug": {
-                "additionalProperties": false,
-                "description": "Debugging options for the build step",
-                "properties": {
-                  "args": {
-                    "additionalProperties": {
-                      "type": "string"
+              'debug': {
+                'additionalProperties': false,
+                'description': 'Debugging options for the build step',
+                'properties': {
+                  'args': {
+                    'additionalProperties': {
+                      'type': 'string',
                     },
-                    "description": "A set of arguments to pass to the build job",
-                    "examples": [
+                    'description': 'A set of arguments to pass to the build job',
+                    'examples': [
                       {
-                        "BUILDKIT_INLINE_CACHE": "1"
-                      }
+                        'BUILDKIT_INLINE_CACHE': '1',
+                      },
                     ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "context": {
-                    "description": "Path to the folder containing the code to build",
-                    "examples": [
-                      "./"
+                  'context': {
+                    'description': 'Path to the folder containing the code to build',
+                    'examples': [
+                      './',
                     ],
-                    "type": "string"
+                    'type': 'string',
                   },
-                  "description": {
-                    "description": "Description of the build artifact",
-                    "examples": [
-                      "Builds the source code for the application"
+                  'description': {
+                    'description': 'Description of the build artifact',
+                    'examples': [
+                      'Builds the source code for the application',
                     ],
-                    "type": "string"
+                    'type': 'string',
                   },
-                  "dockerfile": {
-                    "default": "Dockerfile",
-                    "description": "The path to the dockerfile defining this build step",
-                    "type": "string"
+                  'dockerfile': {
+                    'default': 'Dockerfile',
+                    'description': 'The path to the dockerfile defining this build step',
+                    'type': 'string',
                   },
-                  "image": {
-                    "description": "The resulting image that was created once the build is complete. This will change whenever the component is tagged as well.",
-                    "examples": [
-                      "my-registry.com/my-app:latest"
+                  'image': {
+                    'description':
+                      'The resulting image that was created once the build is complete. This will change whenever the component is tagged as well.',
+                    'examples': [
+                      'my-registry.com/my-app:latest',
                     ],
-                    "type": "string"
+                    'type': 'string',
                   },
-                  "target": {
-                    "description": "The docker target to use during the build process",
-                    "examples": [
-                      "builder"
+                  'target': {
+                    'description': 'The docker target to use during the build process',
+                    'examples': [
+                      'builder',
                     ],
-                    "type": "string"
-                  }
+                    'type': 'string',
+                  },
                 },
-                "type": "object"
+                'type': 'object',
               },
-              "description": {
-                "description": "Description of the build artifact",
-                "examples": [
-                  "Builds the source code for the application"
+              'description': {
+                'description': 'Description of the build artifact',
+                'examples': [
+                  'Builds the source code for the application',
                 ],
-                "type": "string"
+                'type': 'string',
               },
-              "dockerfile": {
-                "default": "Dockerfile",
-                "description": "The path to the dockerfile defining this build step",
-                "type": "string"
+              'dockerfile': {
+                'default': 'Dockerfile',
+                'description': 'The path to the dockerfile defining this build step',
+                'type': 'string',
               },
-              "image": {
-                "description": "The resulting image that was created once the build is complete. This will change whenever the component is tagged as well.",
-                "examples": [
-                  "my-registry.com/my-app:latest"
+              'image': {
+                'description':
+                  'The resulting image that was created once the build is complete. This will change whenever the component is tagged as well.',
+                'examples': [
+                  'my-registry.com/my-app:latest',
                 ],
-                "type": "string"
+                'type': 'string',
               },
-              "target": {
-                "description": "The docker target to use during the build process",
-                "examples": [
-                  "builder"
+              'target': {
+                'description': 'The docker target to use during the build process',
+                'examples': [
+                  'builder',
                 ],
-                "type": "string"
-              }
+                'type': 'string',
+              },
             },
-            "required": [
-              "context"
+            'required': [
+              'context',
             ],
-            "type": "object"
+            'type': 'object',
           },
-          "description": "A set of build jobs to run to power other deployments or tasks",
-          "type": "object"
+          'description': 'A set of build jobs to run to power other deployments or tasks',
+          'type': 'object',
         },
-        "databases": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "description": {
-                "default": "",
-                "description": "A human-readable description of the use-case for the database",
-                "type": "string"
+        'databases': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'description': {
+                'default': '',
+                'description': 'A human-readable description of the use-case for the database',
+                'type': 'string',
               },
-              "migrate": {
-                "additionalProperties": false,
-                "description": "Configuration details for how to run database migrations",
-                "properties": {
-                  "command": {
-                    "anyOf": [
+              'migrate': {
+                'additionalProperties': false,
+                'description': 'Configuration details for how to run database migrations',
+                'properties': {
+                  'command': {
+                    'anyOf': [
                       {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
+                        'type': 'array',
+                      },
                     ],
-                    "description": "A command to run in the container to execute the migration",
-                    "examples": [
+                    'description': 'A command to run in the container to execute the migration',
+                    'examples': [
                       [
-                        "npm",
-                        "run",
-                        "migrate"
-                      ]
-                    ]
+                        'npm',
+                        'run',
+                        'migrate',
+                      ],
+                    ],
                   },
-                  "entrypoint": {
-                    "anyOf": [
+                  'entrypoint': {
+                    'anyOf': [
                       {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
+                        'type': 'array',
+                      },
                     ],
-                    "default": [
-                      ""
+                    'default': [
+                      '',
                     ],
-                    "description": "An entrypoint to use for the docker container"
+                    'description': 'An entrypoint to use for the docker container',
                   },
-                  "environment": {
-                    "additionalProperties": {
-                      "anyOf": [
+                  'environment': {
+                    'additionalProperties': {
+                      'anyOf': [
                         {
-                          "type": "string"
+                          'type': 'string',
                         },
                         {
-                          "type": "number"
+                          'type': 'number',
                         },
                         {
-                          "type": "boolean"
+                          'type': 'boolean',
                         },
                         {
-                          "type": "null"
+                          'type': 'null',
                         },
                         {
-                          "not": {}
-                        }
-                      ]
+                          'not': {},
+                        },
+                      ],
                     },
-                    "description": "Environment variables to set in the container",
-                    "examples": [
+                    'description': 'Environment variables to set in the container',
+                    'examples': [
                       {
-                        "DATABASE_URL": "${{ databases.auth.url }}"
-                      }
+                        'DATABASE_URL': '${{ databases.auth.url }}',
+                      },
                     ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "image": {
-                    "description": "The docker image containing the migration tooling and files",
-                    "examples": [
-                      "${{ builds.api.image }}"
+                  'image': {
+                    'description': 'The docker image containing the migration tooling and files',
+                    'examples': [
+                      '${{ builds.api.image }}',
                     ],
-                    "type": "string"
-                  }
+                    'type': 'string',
+                  },
                 },
-                "required": [
-                  "image"
+                'required': [
+                  'image',
                 ],
-                "type": "object"
+                'type': 'object',
               },
-              "seed": {
-                "additionalProperties": false,
-                "description": "Configuration details for how to seed the database",
-                "properties": {
-                  "command": {
-                    "anyOf": [
+              'seed': {
+                'additionalProperties': false,
+                'description': 'Configuration details for how to seed the database',
+                'properties': {
+                  'command': {
+                    'anyOf': [
                       {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
+                        'type': 'array',
+                      },
                     ],
-                    "description": "A command to run in the container to execute the seeding",
-                    "examples": [
+                    'description': 'A command to run in the container to execute the seeding',
+                    'examples': [
                       [
-                        "npm",
-                        "run",
-                        "seed"
-                      ]
-                    ]
+                        'npm',
+                        'run',
+                        'seed',
+                      ],
+                    ],
                   },
-                  "entrypoint": {
-                    "anyOf": [
+                  'entrypoint': {
+                    'anyOf': [
                       {
-                        "type": "string"
+                        'type': 'string',
                       },
                       {
-                        "items": {
-                          "type": "string"
+                        'items': {
+                          'type': 'string',
                         },
-                        "type": "array"
-                      }
+                        'type': 'array',
+                      },
                     ],
-                    "default": [
-                      ""
+                    'default': [
+                      '',
                     ],
-                    "description": "An entrypoint to use for the docker container"
+                    'description': 'An entrypoint to use for the docker container',
                   },
-                  "environment": {
-                    "additionalProperties": {
-                      "anyOf": [
+                  'environment': {
+                    'additionalProperties': {
+                      'anyOf': [
                         {
-                          "type": "string"
+                          'type': 'string',
                         },
                         {
-                          "type": "number"
+                          'type': 'number',
                         },
                         {
-                          "type": "boolean"
+                          'type': 'boolean',
                         },
                         {
-                          "type": "null"
+                          'type': 'null',
                         },
                         {
-                          "not": {}
-                        }
-                      ]
+                          'not': {},
+                        },
+                      ],
                     },
-                    "description": "Environment variables to set in the container",
-                    "examples": [
+                    'description': 'Environment variables to set in the container',
+                    'examples': [
                       {
-                        "DATABASE_URL": "${{ databases.auth.url }}"
-                      }
+                        'DATABASE_URL': '${{ databases.auth.url }}',
+                      },
                     ],
-                    "type": "object"
+                    'type': 'object',
                   },
-                  "image": {
-                    "description": "The docker image containing the seeding tooling and files",
-                    "examples": [
-                      "${{ builds.api.image }}"
+                  'image': {
+                    'description': 'The docker image containing the seeding tooling and files',
+                    'examples': [
+                      '${{ builds.api.image }}',
                     ],
-                    "type": "string"
-                  }
+                    'type': 'string',
+                  },
                 },
-                "required": [
-                  "image"
+                'required': [
+                  'image',
                 ],
-                "type": "object"
+                'type': 'object',
               },
-              "type": {
-                "description": "The type of database and version to use",
-                "examples": [
-                  "postgres:15",
-                  "mysql:8",
-                  "redis:5"
+              'type': {
+                'description': 'The type of database and version to use',
+                'examples': [
+                  'postgres:15',
+                  'mysql:8',
+                  'redis:5',
                 ],
-                "type": "string"
-              }
+                'type': 'string',
+              },
             },
-            "required": [
-              "type"
+            'required': [
+              'type',
             ],
-            "type": "object"
+            'type': 'object',
           },
-          "description": "A set of databases that this component requires",
-          "type": "object"
+          'description': 'A set of databases that this component requires',
+          'type': 'object',
         },
-        "dependencies": {
-          "additionalProperties": {
-            "anyOf": [
+        'dependencies': {
+          'additionalProperties': {
+            'anyOf': [
               {
-                "type": "string"
+                'type': 'string',
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "component": {
-                    "description": "The repo the component is in",
-                    "type": "string"
+                'additionalProperties': false,
+                'properties': {
+                  'component': {
+                    'description': 'The repo the component is in',
+                    'type': 'string',
                   },
-                  "variables": {
-                    "additionalProperties": {
-                      "anyOf": [
+                  'variables': {
+                    'additionalProperties': {
+                      'anyOf': [
                         {
-                          "type": "string"
+                          'type': 'string',
                         },
                         {
-                          "items": {
-                            "type": "string"
+                          'items': {
+                            'type': 'string',
                           },
-                          "type": "array"
-                        }
-                      ]
+                          'type': 'array',
+                        },
+                      ],
                     },
-                    "description": "Input values to provide to the component if `merge` is turned on",
-                    "examples": [
+                    'description': 'Input values to provide to the component if `merge` is turned on',
+                    'examples': [
                       {
-                        "allowed_return_urls": [
-                          "https://architect.io",
-                          "${{ ingresses.frontend.url }}"
-                        ]
-                      }
+                        'allowed_return_urls': [
+                          'https://architect.io',
+                          '${{ ingresses.frontend.url }}',
+                        ],
+                      },
                     ],
-                    "type": "object"
-                  }
+                    'type': 'object',
+                  },
                 },
-                "required": [
-                  "component"
+                'required': [
+                  'component',
                 ],
-                "type": "object"
-              }
-            ]
+                'type': 'object',
+              },
+            ],
           },
-          "description": "A set of other components that this component depends on",
-          "examples": [
+          'description': 'A set of other components that this component depends on',
+          'examples': [
             {
-              "auth": {
-                "component": "architect/auth-component",
-                "variables": {
-                  "allowed_return_urls": [
-                    "https://architect.io",
-                    "${{ ingresses.frontend.url }}"
-                  ]
-                }
-              },
-              "payments": "architect/payments-component"
-            }
-          ],
-          "type": "object"
-        },
-        "deployments": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "autoscaling": {
-                "additionalProperties": false,
-                "description": "Configuration settings for how to automatically scale the application up and down",
-                "properties": {
-                  "cpu": {
-                    "description": "Maximum number of CPUs to allocate to each replica",
-                    "examples": [
-                      "0.5",
-                      "1"
-                    ],
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "memory": {
-                    "description": "Maximum memory usage per replica before scaling up",
-                    "examples": [
-                      "200Mi",
-                      "2Gi"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              },
-              "command": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                ],
-                "description": "Command to use when the container is booted up",
-                "examples": [
-                  [
-                    "npm",
-                    "start"
-                  ]
-                ]
-              },
-              "cpu": {
-                "description": "The amount of CPU to allocate to each instance of the deployment",
-                "type": [
-                  "number",
-                  "string"
-                ]
-              },
-              "debug": {
-                "additionalProperties": false,
-                "description": "Debugging options for the deployment",
-                "properties": {
-                  "autoscaling": {
-                    "additionalProperties": false,
-                    "description": "Configuration settings for how to automatically scale the application up and down",
-                    "properties": {
-                      "cpu": {
-                        "description": "Maximum number of CPUs to allocate to each replica",
-                        "examples": [
-                          "0.5",
-                          "1"
-                        ],
-                        "type": [
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "memory": {
-                        "description": "Maximum memory usage per replica before scaling up",
-                        "examples": [
-                          "200Mi",
-                          "2Gi"
-                        ],
-                        "type": "string"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "command": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ],
-                    "description": "Command to use when the container is booted up",
-                    "examples": [
-                      [
-                        "npm",
-                        "start"
-                      ]
-                    ]
-                  },
-                  "cpu": {
-                    "description": "The amount of CPU to allocate to each instance of the deployment",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "description": {
-                    "description": "Human readable description of the deployment",
-                    "examples": [
-                      "Runs the frontend web application"
-                    ],
-                    "type": "string"
-                  },
-                  "entrypoint": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ],
-                    "default": [
-                      ""
-                    ],
-                    "description": "The executable to run every time the container is booted up"
-                  },
-                  "environment": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Environment variables to pass to the service",
-                    "examples": [
-                      {
-                        "NODE_ENV": "production"
-                      },
-                      {
-                        "BACKEND_URL": "${{ ingresses.backend.url }}"
-                      }
-                    ],
-                    "type": "object"
-                  },
-                  "image": {
-                    "description": "Docker image to use for the deployment",
-                    "examples": [
-                      "${{ builds.frontend.image }}",
-                      "my-registry.com/my-app:latest"
-                    ],
-                    "type": "string"
-                  },
-                  "labels": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "The labels to apply to the deployment",
-                    "type": "object"
-                  },
-                  "memory": {
-                    "description": "The amount of memory to allocate to each instance of the deployment",
-                    "type": "string"
-                  },
-                  "platform": {
-                    "description": "Set platform if server is multi-platform capable",
-                    "examples": [
-                      "linux/amd64"
-                    ],
-                    "type": "string"
-                  },
-                  "probes": {
-                    "additionalProperties": false,
-                    "description": "Configuration details for probes that check each replicas status",
-                    "properties": {
-                      "liveness": {
-                        "anyOf": [
-                          {
-                            "additionalProperties": false,
-                            "properties": {
-                              "command": {
-                                "description": "Command to run inside the container to determine if its healthy",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              "failure_threshold": {
-                                "default": 3,
-                                "description": "Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "initial_delay": {
-                                "default": 0,
-                                "description": "Number of seconds after the container starts before the probe is initiated.",
-                                "minimum": 0,
-                                "type": "number"
-                              },
-                              "interval": {
-                                "default": 10,
-                                "description": "How often (in seconds) to perform the probe.",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "success_threshold": {
-                                "default": 1,
-                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "timeout": {
-                                "default": 1,
-                                "description": "Number of seconds after which the probe times out",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "type": {
-                                "const": "exec",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "command",
-                              "type"
-                            ],
-                            "type": "object"
-                          },
-                          {
-                            "additionalProperties": false,
-                            "properties": {
-                              "failure_threshold": {
-                                "default": 3,
-                                "description": "Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "headers": {
-                                "description": "Custom headers to set in the request.",
-                                "items": {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "value": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "name",
-                                    "value"
-                                  ],
-                                  "type": "object"
-                                },
-                                "type": "array"
-                              },
-                              "initial_delay": {
-                                "default": 0,
-                                "description": "Number of seconds after the container starts before the probe is initiated.",
-                                "minimum": 0,
-                                "type": "number"
-                              },
-                              "interval": {
-                                "default": 10,
-                                "description": "How often (in seconds) to perform the probe.",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "path": {
-                                "default": "/",
-                                "description": "Path to access on the http server",
-                                "type": "string"
-                              },
-                              "port": {
-                                "description": "Port to access on the container",
-                                "type": "number"
-                              },
-                              "scheme": {
-                                "default": "http",
-                                "description": "Scheme to use for connecting to the host (http or https).",
-                                "type": "string"
-                              },
-                              "success_threshold": {
-                                "default": 1,
-                                "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "timeout": {
-                                "default": 1,
-                                "description": "Number of seconds after which the probe times out",
-                                "minimum": 1,
-                                "type": "number"
-                              },
-                              "type": {
-                                "const": "http",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "type"
-                            ],
-                            "type": "object"
-                          }
-                        ],
-                        "description": "Configuration settings to determine if the deployment is ready to receive traffic"
-                      }
-                    },
-                    "type": "object"
-                  },
-                  "volumes": {
-                    "additionalProperties": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "host_path": {
-                          "description": "Path on the host machine to sync with the volume",
-                          "examples": [
-                            "/Users/batman/app/src"
-                          ],
-                          "type": "string"
-                        },
-                        "image": {
-                          "description": "OCI image containing the contents to seed the volume with",
-                          "type": "string"
-                        },
-                        "mount_path": {
-                          "description": "Path inside the container to mount the volume to",
-                          "examples": [
-                            "/app/src"
-                          ],
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "mount_path"
-                      ],
-                      "type": "object"
-                    },
-                    "description": "Volumes that should be created and attached to each replica",
-                    "type": "object"
-                  }
-                },
-                "type": "object"
-              },
-              "description": {
-                "description": "Human readable description of the deployment",
-                "examples": [
-                  "Runs the frontend web application"
-                ],
-                "type": "string"
-              },
-              "entrypoint": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                ],
-                "default": [
-                  ""
-                ],
-                "description": "The executable to run every time the container is booted up"
-              },
-              "environment": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "Environment variables to pass to the service",
-                "examples": [
-                  {
-                    "NODE_ENV": "production"
-                  },
-                  {
-                    "BACKEND_URL": "${{ ingresses.backend.url }}"
-                  }
-                ],
-                "type": "object"
-              },
-              "image": {
-                "description": "Docker image to use for the deployment",
-                "examples": [
-                  "${{ builds.frontend.image }}",
-                  "my-registry.com/my-app:latest"
-                ],
-                "type": "string"
-              },
-              "labels": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "The labels to apply to the deployment",
-                "type": "object"
-              },
-              "memory": {
-                "description": "The amount of memory to allocate to each instance of the deployment",
-                "type": "string"
-              },
-              "platform": {
-                "description": "Set platform if server is multi-platform capable",
-                "examples": [
-                  "linux/amd64"
-                ],
-                "type": "string"
-              },
-              "probes": {
-                "additionalProperties": false,
-                "description": "Configuration details for probes that check each replicas status",
-                "properties": {
-                  "liveness": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "command": {
-                            "description": "Command to run inside the container to determine if its healthy",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "failure_threshold": {
-                            "default": 3,
-                            "description": "Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "initial_delay": {
-                            "default": 0,
-                            "description": "Number of seconds after the container starts before the probe is initiated.",
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "interval": {
-                            "default": 10,
-                            "description": "How often (in seconds) to perform the probe.",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "success_threshold": {
-                            "default": 1,
-                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "timeout": {
-                            "default": 1,
-                            "description": "Number of seconds after which the probe times out",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "type": {
-                            "const": "exec",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "command",
-                          "type"
-                        ],
-                        "type": "object"
-                      },
-                      {
-                        "additionalProperties": false,
-                        "properties": {
-                          "failure_threshold": {
-                            "default": 3,
-                            "description": "Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "headers": {
-                            "description": "Custom headers to set in the request.",
-                            "items": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "name": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "value"
-                              ],
-                              "type": "object"
-                            },
-                            "type": "array"
-                          },
-                          "initial_delay": {
-                            "default": 0,
-                            "description": "Number of seconds after the container starts before the probe is initiated.",
-                            "minimum": 0,
-                            "type": "number"
-                          },
-                          "interval": {
-                            "default": 10,
-                            "description": "How often (in seconds) to perform the probe.",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "path": {
-                            "default": "/",
-                            "description": "Path to access on the http server",
-                            "type": "string"
-                          },
-                          "port": {
-                            "description": "Port to access on the container",
-                            "type": "number"
-                          },
-                          "scheme": {
-                            "default": "http",
-                            "description": "Scheme to use for connecting to the host (http or https).",
-                            "type": "string"
-                          },
-                          "success_threshold": {
-                            "default": 1,
-                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "timeout": {
-                            "default": 1,
-                            "description": "Number of seconds after which the probe times out",
-                            "minimum": 1,
-                            "type": "number"
-                          },
-                          "type": {
-                            "const": "http",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type"
-                        ],
-                        "type": "object"
-                      }
-                    ],
-                    "description": "Configuration settings to determine if the deployment is ready to receive traffic"
-                  }
-                },
-                "type": "object"
-              },
-              "volumes": {
-                "additionalProperties": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "host_path": {
-                      "description": "Path on the host machine to sync with the volume",
-                      "examples": [
-                        "/Users/batman/app/src"
-                      ],
-                      "type": "string"
-                    },
-                    "image": {
-                      "description": "OCI image containing the contents to seed the volume with",
-                      "type": "string"
-                    },
-                    "mount_path": {
-                      "description": "Path inside the container to mount the volume to",
-                      "examples": [
-                        "/app/src"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "mount_path"
+              'auth': {
+                'component': 'architect/auth-component',
+                'variables': {
+                  'allowed_return_urls': [
+                    'https://architect.io',
+                    '${{ ingresses.frontend.url }}',
                   ],
-                  "type": "object"
                 },
-                "description": "Volumes that should be created and attached to each replica",
-                "type": "object"
-              }
+              },
+              'payments': 'architect/payments-component',
             },
-            "required": [
-              "image"
-            ],
-            "type": "object"
-          },
-          "description": "Workloads that should be deployed",
-          "type": "object"
+          ],
+          'type': 'object',
         },
-        "ingresses": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "headers": {
-                "additionalProperties": {
-                  "type": "string"
+        'deployments': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'autoscaling': {
+                'additionalProperties': false,
+                'description': 'Configuration settings for how to automatically scale the application up and down',
+                'properties': {
+                  'cpu': {
+                    'description': 'Maximum number of CPUs to allocate to each replica',
+                    'examples': [
+                      '0.5',
+                      '1',
+                    ],
+                    'type': [
+                      'number',
+                      'string',
+                    ],
+                  },
+                  'memory': {
+                    'description': 'Maximum memory usage per replica before scaling up',
+                    'examples': [
+                      '200Mi',
+                      '2Gi',
+                    ],
+                    'type': 'string',
+                  },
                 },
-                "description": "Additional headers to include in responses",
-                "examples": [
+                'type': 'object',
+              },
+              'command': {
+                'anyOf': [
                   {
-                    "Access-Control-Allow-Credentials": "true",
-                    "Access-Control-Allow-Origin": "${{ variables.allowed_return_urls }}"
-                  }
-                ],
-                "type": "object"
-              },
-              "internal": {
-                "default": false,
-                "description": "Whether or not the ingress rule should be attached to an internal gateway",
-                "type": "boolean"
-              },
-              "service": {
-                "description": "Service the ingress rule forwards traffic to",
-                "examples": [
-                  "backend"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "service"
-            ],
-            "type": "object"
-          },
-          "description": "Claims for external (e.g. client) access to a service",
-          "type": "object"
-        },
-        "services": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "deployment": {
-                "description": "Deployment the service sends requests to",
-                "examples": [
-                  "backend"
-                ],
-                "type": "string"
-              },
-              "description": {
-                "description": "Description of the service",
-                "examples": [
-                  "Exposes the backend to other applications"
-                ],
-                "type": "string"
-              },
-              "password": {
-                "description": "Basic auth password",
-                "type": "string"
-              },
-              "port": {
-                "description": "Port the service listens on",
-                "examples": [
-                  8080
-                ],
-                "type": "number"
-              },
-              "protocol": {
-                "default": "http",
-                "description": "Protocol the service listens on",
-                "type": "string"
-              },
-              "username": {
-                "description": "Basic auth username",
-                "type": "string"
-              }
-            },
-            "required": [
-              "deployment",
-              "port"
-            ],
-            "type": "object"
-          },
-          "description": "Services that can receive network traffic",
-          "type": "object"
-        },
-        "variables": {
-          "additionalProperties": {
-            "additionalProperties": false,
-            "properties": {
-              "default": {
-                "anyOf": [
-                  {
-                    "type": "string"
+                    'type': 'string',
                   },
                   {
-                    "items": {
-                      "type": "string"
+                    'items': {
+                      'type': 'string',
                     },
-                    "type": "array"
-                  }
+                    'type': 'array',
+                  },
                 ],
-                "description": "A default value to use if one isn't provided",
-                "examples": [
-                  "https://architect.io"
-                ]
-              },
-              "description": {
-                "description": "A human-readable description",
-                "examples": [
-                  "API key used to authenticate with Stripe"
+                'description': 'Command to use when the container is booted up',
+                'examples': [
+                  [
+                    'npm',
+                    'start',
+                  ],
                 ],
-                "type": "string"
               },
-              "merge": {
-                "default": false,
-                "description": "If true, upstream components can pass in values that will be merged together with each other and environment-provided values",
-                "type": "boolean"
+              'cpu': {
+                'description': 'The amount of CPU to allocate to each instance of the deployment',
+                'type': [
+                  'number',
+                  'string',
+                ],
               },
-              "required": {
-                "default": false,
-                "description": "If true, a value is required or the component won't run.",
-                "type": "boolean"
+              'debug': {
+                'additionalProperties': false,
+                'description': 'Debugging options for the deployment',
+                'properties': {
+                  'autoscaling': {
+                    'additionalProperties': false,
+                    'description': 'Configuration settings for how to automatically scale the application up and down',
+                    'properties': {
+                      'cpu': {
+                        'description': 'Maximum number of CPUs to allocate to each replica',
+                        'examples': [
+                          '0.5',
+                          '1',
+                        ],
+                        'type': [
+                          'number',
+                          'string',
+                        ],
+                      },
+                      'memory': {
+                        'description': 'Maximum memory usage per replica before scaling up',
+                        'examples': [
+                          '200Mi',
+                          '2Gi',
+                        ],
+                        'type': 'string',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'command': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                    'description': 'Command to use when the container is booted up',
+                    'examples': [
+                      [
+                        'npm',
+                        'start',
+                      ],
+                    ],
+                  },
+                  'cpu': {
+                    'description': 'The amount of CPU to allocate to each instance of the deployment',
+                    'type': [
+                      'number',
+                      'string',
+                    ],
+                  },
+                  'description': {
+                    'description': 'Human readable description of the deployment',
+                    'examples': [
+                      'Runs the frontend web application',
+                    ],
+                    'type': 'string',
+                  },
+                  'entrypoint': {
+                    'anyOf': [
+                      {
+                        'type': 'string',
+                      },
+                      {
+                        'items': {
+                          'type': 'string',
+                        },
+                        'type': 'array',
+                      },
+                    ],
+                    'default': [
+                      '',
+                    ],
+                    'description': 'The executable to run every time the container is booted up',
+                  },
+                  'environment': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'description': 'Environment variables to pass to the service',
+                    'examples': [
+                      {
+                        'NODE_ENV': 'production',
+                      },
+                      {
+                        'BACKEND_URL': '${{ ingresses.backend.url }}',
+                      },
+                    ],
+                    'type': 'object',
+                  },
+                  'image': {
+                    'description': 'Docker image to use for the deployment',
+                    'examples': [
+                      '${{ builds.frontend.image }}',
+                      'my-registry.com/my-app:latest',
+                    ],
+                    'type': 'string',
+                  },
+                  'labels': {
+                    'additionalProperties': {
+                      'type': 'string',
+                    },
+                    'description': 'The labels to apply to the deployment',
+                    'type': 'object',
+                  },
+                  'memory': {
+                    'description': 'The amount of memory to allocate to each instance of the deployment',
+                    'type': 'string',
+                  },
+                  'platform': {
+                    'description': 'Set platform if server is multi-platform capable',
+                    'examples': [
+                      'linux/amd64',
+                    ],
+                    'type': 'string',
+                  },
+                  'probes': {
+                    'additionalProperties': false,
+                    'description': 'Configuration details for probes that check each replicas status',
+                    'properties': {
+                      'liveness': {
+                        'anyOf': [
+                          {
+                            'additionalProperties': false,
+                            'properties': {
+                              'command': {
+                                'description': 'Command to run inside the container to determine if its healthy',
+                                'items': {
+                                  'type': 'string',
+                                },
+                                'type': 'array',
+                              },
+                              'failure_threshold': {
+                                'default': 3,
+                                'description':
+                                  'Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'initial_delay': {
+                                'default': 0,
+                                'description':
+                                  'Number of seconds after the container starts before the probe is initiated.',
+                                'minimum': 0,
+                                'type': 'number',
+                              },
+                              'interval': {
+                                'default': 10,
+                                'description': 'How often (in seconds) to perform the probe.',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'success_threshold': {
+                                'default': 1,
+                                'description':
+                                  'Minimum consecutive successes for the probe to be considered successful after having failed.',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'timeout': {
+                                'default': 1,
+                                'description': 'Number of seconds after which the probe times out',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'type': {
+                                'const': 'exec',
+                                'type': 'string',
+                              },
+                            },
+                            'required': [
+                              'command',
+                              'type',
+                            ],
+                            'type': 'object',
+                          },
+                          {
+                            'additionalProperties': false,
+                            'properties': {
+                              'failure_threshold': {
+                                'default': 3,
+                                'description':
+                                  'Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'headers': {
+                                'description': 'Custom headers to set in the request.',
+                                'items': {
+                                  'additionalProperties': false,
+                                  'properties': {
+                                    'name': {
+                                      'type': 'string',
+                                    },
+                                    'value': {
+                                      'type': 'string',
+                                    },
+                                  },
+                                  'required': [
+                                    'name',
+                                    'value',
+                                  ],
+                                  'type': 'object',
+                                },
+                                'type': 'array',
+                              },
+                              'initial_delay': {
+                                'default': 0,
+                                'description':
+                                  'Number of seconds after the container starts before the probe is initiated.',
+                                'minimum': 0,
+                                'type': 'number',
+                              },
+                              'interval': {
+                                'default': 10,
+                                'description': 'How often (in seconds) to perform the probe.',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'path': {
+                                'default': '/',
+                                'description': 'Path to access on the http server',
+                                'type': 'string',
+                              },
+                              'port': {
+                                'description': 'Port to access on the container',
+                                'type': 'number',
+                              },
+                              'scheme': {
+                                'default': 'http',
+                                'description': 'Scheme to use for connecting to the host (http or https).',
+                                'type': 'string',
+                              },
+                              'success_threshold': {
+                                'default': 1,
+                                'description':
+                                  'Minimum consecutive successes for the probe to be considered successful after having failed.',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'timeout': {
+                                'default': 1,
+                                'description': 'Number of seconds after which the probe times out',
+                                'minimum': 1,
+                                'type': 'number',
+                              },
+                              'type': {
+                                'const': 'http',
+                                'type': 'string',
+                              },
+                            },
+                            'required': [
+                              'type',
+                            ],
+                            'type': 'object',
+                          },
+                        ],
+                        'description':
+                          'Configuration settings to determine if the deployment is ready to receive traffic',
+                      },
+                    },
+                    'type': 'object',
+                  },
+                  'volumes': {
+                    'additionalProperties': {
+                      'additionalProperties': false,
+                      'properties': {
+                        'host_path': {
+                          'description': 'Path on the host machine to sync with the volume',
+                          'examples': [
+                            '/Users/batman/app/src',
+                          ],
+                          'type': 'string',
+                        },
+                        'image': {
+                          'description': 'OCI image containing the contents to seed the volume with',
+                          'type': 'string',
+                        },
+                        'mount_path': {
+                          'description': 'Path inside the container to mount the volume to',
+                          'examples': [
+                            '/app/src',
+                          ],
+                          'type': 'string',
+                        },
+                      },
+                      'required': [
+                        'mount_path',
+                      ],
+                      'type': 'object',
+                    },
+                    'description': 'Volumes that should be created and attached to each replica',
+                    'type': 'object',
+                  },
+                },
+                'type': 'object',
               },
-              "sensitive": {
-                "default": false,
-                "description": "Whether or not the data should be considered sensitive and stripped from logs",
-                "type": "boolean"
-              }
+              'description': {
+                'description': 'Human readable description of the deployment',
+                'examples': [
+                  'Runs the frontend web application',
+                ],
+                'type': 'string',
+              },
+              'entrypoint': {
+                'anyOf': [
+                  {
+                    'type': 'string',
+                  },
+                  {
+                    'items': {
+                      'type': 'string',
+                    },
+                    'type': 'array',
+                  },
+                ],
+                'default': [
+                  '',
+                ],
+                'description': 'The executable to run every time the container is booted up',
+              },
+              'environment': {
+                'additionalProperties': {
+                  'type': 'string',
+                },
+                'description': 'Environment variables to pass to the service',
+                'examples': [
+                  {
+                    'NODE_ENV': 'production',
+                  },
+                  {
+                    'BACKEND_URL': '${{ ingresses.backend.url }}',
+                  },
+                ],
+                'type': 'object',
+              },
+              'image': {
+                'description': 'Docker image to use for the deployment',
+                'examples': [
+                  '${{ builds.frontend.image }}',
+                  'my-registry.com/my-app:latest',
+                ],
+                'type': 'string',
+              },
+              'labels': {
+                'additionalProperties': {
+                  'type': 'string',
+                },
+                'description': 'The labels to apply to the deployment',
+                'type': 'object',
+              },
+              'memory': {
+                'description': 'The amount of memory to allocate to each instance of the deployment',
+                'type': 'string',
+              },
+              'platform': {
+                'description': 'Set platform if server is multi-platform capable',
+                'examples': [
+                  'linux/amd64',
+                ],
+                'type': 'string',
+              },
+              'probes': {
+                'additionalProperties': false,
+                'description': 'Configuration details for probes that check each replicas status',
+                'properties': {
+                  'liveness': {
+                    'anyOf': [
+                      {
+                        'additionalProperties': false,
+                        'properties': {
+                          'command': {
+                            'description': 'Command to run inside the container to determine if its healthy',
+                            'items': {
+                              'type': 'string',
+                            },
+                            'type': 'array',
+                          },
+                          'failure_threshold': {
+                            'default': 3,
+                            'description':
+                              'Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'initial_delay': {
+                            'default': 0,
+                            'description':
+                              'Number of seconds after the container starts before the probe is initiated.',
+                            'minimum': 0,
+                            'type': 'number',
+                          },
+                          'interval': {
+                            'default': 10,
+                            'description': 'How often (in seconds) to perform the probe.',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'success_threshold': {
+                            'default': 1,
+                            'description':
+                              'Minimum consecutive successes for the probe to be considered successful after having failed.',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'timeout': {
+                            'default': 1,
+                            'description': 'Number of seconds after which the probe times out',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'type': {
+                            'const': 'exec',
+                            'type': 'string',
+                          },
+                        },
+                        'required': [
+                          'command',
+                          'type',
+                        ],
+                        'type': 'object',
+                      },
+                      {
+                        'additionalProperties': false,
+                        'properties': {
+                          'failure_threshold': {
+                            'default': 3,
+                            'description':
+                              'Number of times the probe will tolerate failure before giving up. Giving up in the case of liveness probe means restarting the container.',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'headers': {
+                            'description': 'Custom headers to set in the request.',
+                            'items': {
+                              'additionalProperties': false,
+                              'properties': {
+                                'name': {
+                                  'type': 'string',
+                                },
+                                'value': {
+                                  'type': 'string',
+                                },
+                              },
+                              'required': [
+                                'name',
+                                'value',
+                              ],
+                              'type': 'object',
+                            },
+                            'type': 'array',
+                          },
+                          'initial_delay': {
+                            'default': 0,
+                            'description':
+                              'Number of seconds after the container starts before the probe is initiated.',
+                            'minimum': 0,
+                            'type': 'number',
+                          },
+                          'interval': {
+                            'default': 10,
+                            'description': 'How often (in seconds) to perform the probe.',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'path': {
+                            'default': '/',
+                            'description': 'Path to access on the http server',
+                            'type': 'string',
+                          },
+                          'port': {
+                            'description': 'Port to access on the container',
+                            'type': 'number',
+                          },
+                          'scheme': {
+                            'default': 'http',
+                            'description': 'Scheme to use for connecting to the host (http or https).',
+                            'type': 'string',
+                          },
+                          'success_threshold': {
+                            'default': 1,
+                            'description':
+                              'Minimum consecutive successes for the probe to be considered successful after having failed.',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'timeout': {
+                            'default': 1,
+                            'description': 'Number of seconds after which the probe times out',
+                            'minimum': 1,
+                            'type': 'number',
+                          },
+                          'type': {
+                            'const': 'http',
+                            'type': 'string',
+                          },
+                        },
+                        'required': [
+                          'type',
+                        ],
+                        'type': 'object',
+                      },
+                    ],
+                    'description': 'Configuration settings to determine if the deployment is ready to receive traffic',
+                  },
+                },
+                'type': 'object',
+              },
+              'volumes': {
+                'additionalProperties': {
+                  'additionalProperties': false,
+                  'properties': {
+                    'host_path': {
+                      'description': 'Path on the host machine to sync with the volume',
+                      'examples': [
+                        '/Users/batman/app/src',
+                      ],
+                      'type': 'string',
+                    },
+                    'image': {
+                      'description': 'OCI image containing the contents to seed the volume with',
+                      'type': 'string',
+                    },
+                    'mount_path': {
+                      'description': 'Path inside the container to mount the volume to',
+                      'examples': [
+                        '/app/src',
+                      ],
+                      'type': 'string',
+                    },
+                  },
+                  'required': [
+                    'mount_path',
+                  ],
+                  'type': 'object',
+                },
+                'description': 'Volumes that should be created and attached to each replica',
+                'type': 'object',
+              },
             },
-            "type": "object"
+            'required': [
+              'image',
+            ],
+            'type': 'object',
           },
-          "description": "A set of inputs the component expects to be provided",
-          "type": "object"
+          'description': 'Workloads that should be deployed',
+          'type': 'object',
         },
-        "version": {
-          "const": "v2",
-          "type": "string"
-        }
+        'ingresses': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'headers': {
+                'additionalProperties': {
+                  'type': 'string',
+                },
+                'description': 'Additional headers to include in responses',
+                'examples': [
+                  {
+                    'Access-Control-Allow-Credentials': 'true',
+                    'Access-Control-Allow-Origin': '${{ variables.allowed_return_urls }}',
+                  },
+                ],
+                'type': 'object',
+              },
+              'internal': {
+                'default': false,
+                'description': 'Whether or not the ingress rule should be attached to an internal gateway',
+                'type': 'boolean',
+              },
+              'service': {
+                'description': 'Service the ingress rule forwards traffic to',
+                'examples': [
+                  'backend',
+                ],
+                'type': 'string',
+              },
+            },
+            'required': [
+              'service',
+            ],
+            'type': 'object',
+          },
+          'description': 'Claims for external (e.g. client) access to a service',
+          'type': 'object',
+        },
+        'services': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'deployment': {
+                'description': 'Deployment the service sends requests to',
+                'examples': [
+                  'backend',
+                ],
+                'type': 'string',
+              },
+              'description': {
+                'description': 'Description of the service',
+                'examples': [
+                  'Exposes the backend to other applications',
+                ],
+                'type': 'string',
+              },
+              'password': {
+                'description': 'Basic auth password',
+                'type': 'string',
+              },
+              'port': {
+                'description': 'Port the service listens on',
+                'examples': [
+                  8080,
+                ],
+                'type': 'number',
+              },
+              'protocol': {
+                'default': 'http',
+                'description': 'Protocol the service listens on',
+                'type': 'string',
+              },
+              'username': {
+                'description': 'Basic auth username',
+                'type': 'string',
+              },
+            },
+            'required': [
+              'deployment',
+              'port',
+            ],
+            'type': 'object',
+          },
+          'description': 'Services that can receive network traffic',
+          'type': 'object',
+        },
+        'variables': {
+          'additionalProperties': {
+            'additionalProperties': false,
+            'properties': {
+              'default': {
+                'anyOf': [
+                  {
+                    'type': 'string',
+                  },
+                  {
+                    'items': {
+                      'type': 'string',
+                    },
+                    'type': 'array',
+                  },
+                ],
+                'description': 'A default value to use if one isn\'t provided',
+                'examples': [
+                  'https://architect.io',
+                ],
+              },
+              'description': {
+                'description': 'A human-readable description',
+                'examples': [
+                  'API key used to authenticate with Stripe',
+                ],
+                'type': 'string',
+              },
+              'merge': {
+                'default': false,
+                'description':
+                  'If true, upstream components can pass in values that will be merged together with each other and environment-provided values',
+                'type': 'boolean',
+              },
+              'required': {
+                'default': false,
+                'description': 'If true, a value is required or the component won\'t run.',
+                'type': 'boolean',
+              },
+              'sensitive': {
+                'default': false,
+                'description': 'Whether or not the data should be considered sensitive and stripped from logs',
+                'type': 'boolean',
+              },
+            },
+            'type': 'object',
+          },
+          'description': 'A set of inputs the component expects to be provided',
+          'type': 'object',
+        },
+        'version': {
+          'const': 'v2',
+          'type': 'string',
+        },
       },
-      "required": [
-        "version"
+      'required': [
+        'version',
       ],
-      "type": "object"
-    }
+      'type': 'object',
+    },
   ],
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://architect.io/.schemas/component.json",
-  "type": "object",
-  "required": [
-    "version"
+  '$schema': 'https://json-schema.org/draft/2019-09/schema',
+  '$id': 'https://architect.io/.schemas/component.json',
+  'type': 'object',
+  'required': [
+    'version',
   ],
-  "discriminator": {
-    "propertyName": "version"
-  }
-}
+  'discriminator': {
+    'propertyName': 'version',
+  },
+};

--- a/src/components/schema.ts
+++ b/src/components/schema.ts
@@ -7,8 +7,7 @@ export type ComponentSchema =
   } & component_v1)
   | ({
     version: 'v2';
-  } & component_v2)
-;
+  } & component_v2);
 
 export const buildComponent = (data: ComponentSchema) => {
   switch (data.version) {

--- a/src/datacenter-modules/types.ts
+++ b/src/datacenter-modules/types.ts
@@ -1,9 +1,14 @@
 import { Logger } from 'winston';
 
-export type Plugin = 'pulumi' | 'opentofu';
+export const PluginArray = ['pulumi', 'opentofu'] as const;
+export type Plugin = typeof PluginArray[number];
+export function isPlugin(x: unknown): x is Plugin {
+  return PluginArray.includes(x as any);
+}
 
 export type BuildRequest = {
   directory: string;
+  platform?: string;
 };
 
 export type BuildOptions = {


### PR DESCRIPTION
## Description

The "source" field of a datacenter now supports a URL which we will `git clone` and build from during the build process. To enable building a specific folder within a repo, we use the syntax Terraform modules use: https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories.

E.g. 
```hcl
module "vpc" {
  # '//' is used to separate the folder within the repo from the repo itself
  # This will clone the `datacenter-modules` repo and build the `aws/vpc` module found here https://github.com/architect-team/datacenter-modules/tree/main/aws/vpc
  build = "https://github.com/architect-team/datacenter-modules//aws/vpc"
  plugin = "opentofu"
  inputs = {
    access_key = variable.access_key
    secret_key = variable.secret_key
    region  = variable.region
    name    = "${datacenter.name}-datacenter"
  }
}

module "vpc" {
  # 'source' can point to an existing image which will be pulled and used to apply the module, the build
  # step is skipped in this case as it is already built.
  source = "tyleraldrich/awsvpc:latest"
  plugin = "opentofu"
  inputs = {
    access_key = variable.access_key
    secret_key = variable.secret_key
    region  = variable.region
    name    = "${datacenter.name}-datacenter"
  }
}
```

The `--platform` command is supported by `arcctl build module` so that a module image for different architectures can be built. The building happens within the plugins, so this change was made there to support this: https://github.com/architect-team/arcctl-plugins/commit/d2cf36a6baf92e91767b1f935b0b049a0d26f8d7